### PR TITLE
added grafana panel with contracts configs crc32

### DIFF
--- a/collector/config/config.go
+++ b/collector/config/config.go
@@ -14,6 +14,8 @@ const (
 
 	// TODO: use an actual address after validators_registry deployment.
 	DefaultValidatorRegistryAddress = "terra1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	DefaultAirDropRegistryContract  = "terra_dummy_airdrop"
+	DefaultRewardDispatcherContract = "terra_dummy_rewarddispatcher"
 )
 
 type CollectorConfig struct {
@@ -24,6 +26,8 @@ type CollectorConfig struct {
 	BlunaTokenInfoContract      string
 	UpdateGlobalIndexBotAddress string
 	ValidatorRegistryAddress    string
+	RewardDispatcherContract    string
+	AirDropRegistryContract     string
 	Schemes                     []string
 }
 
@@ -57,5 +61,9 @@ func DefaultCollectorConfig() CollectorConfig {
 		BlunaTokenInfoContract:      DefaultBlunaTokenInfoContract,
 		UpdateGlobalIndexBotAddress: DefaultUpdateGlobalIndexBotAddress,
 		ValidatorRegistryAddress:    DefaultValidatorRegistryAddress,
+
+		// change the fields to appropriate contracts values
+		AirDropRegistryContract:  DefaultAirDropRegistryContract,
+		RewardDispatcherContract: DefaultRewardDispatcherContract,
 	}
 }

--- a/collector/monitors/configs_monitor.go
+++ b/collector/monitors/configs_monitor.go
@@ -1,0 +1,92 @@
+package monitors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/lidofinance/terra-monitors/collector/config"
+	"github.com/lidofinance/terra-monitors/collector/types"
+	"github.com/lidofinance/terra-monitors/openapi/client"
+	"github.com/lidofinance/terra-monitors/openapi/client/wasm"
+	"github.com/sirupsen/logrus"
+	"hash/crc32"
+)
+
+const (
+	AirDropRegistryConfigCRC32    Metric = "airdrop_registry_config_crc32"
+	BlunaRewardConfigCRC32        Metric = "bluna_reward_config_crc32"
+	HubConfigCRC32                Metric = "hub_config_crc32"
+	RewardDispatcherConfigCRC32   Metric = "reward_dispatcher_config_crc32"
+	ValidatorsRegistryConfigCRC32 Metric = "validators_registry_config_crc32"
+)
+
+type ConfigsCRC32Monitor struct {
+	Contracts map[string]Metric
+	metrics   map[Metric]float64
+	apiClient *client.TerraLiteForTerra
+	logger    *logrus.Logger
+}
+
+func NewConfigsCRC32Monitor(cfg config.CollectorConfig) ConfigsCRC32Monitor {
+	m := ConfigsCRC32Monitor{
+		Contracts: map[string]Metric{
+			cfg.AirDropRegistryContract:  AirDropRegistryConfigCRC32,
+			cfg.ValidatorRegistryAddress: ValidatorsRegistryConfigCRC32,
+			cfg.RewardDispatcherContract: RewardDispatcherConfigCRC32,
+			cfg.HubContract:              HubConfigCRC32,
+			cfg.RewardContract:           BlunaRewardConfigCRC32,
+		},
+		metrics:   make(map[Metric]float64),
+		apiClient: cfg.GetTerraClient(),
+		logger:    cfg.Logger,
+	}
+
+	return m
+}
+
+func (m ConfigsCRC32Monitor) Name() string {
+	return "ConfigsCRC32Monitor"
+}
+
+func (m *ConfigsCRC32Monitor) InitMetrics() {
+	m.metrics[AirDropRegistryConfigCRC32] = 0
+	m.metrics[ValidatorsRegistryConfigCRC32] = 0
+	m.metrics[RewardDispatcherConfigCRC32] = 0
+	m.metrics[HubConfigCRC32] = 0
+	m.metrics[BlunaRewardConfigCRC32] = 0
+}
+
+func (m ConfigsCRC32Monitor) GetMetrics() map[Metric]float64 {
+	return m.metrics
+}
+
+func (m *ConfigsCRC32Monitor) Handler(ctx context.Context) error {
+	confReq := types.CommonConfigRequest{}
+
+	reqRaw, err := json.Marshal(&confReq)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s request: %w", m.Name(), err)
+	}
+
+	p := wasm.GetWasmContractsContractAddressStoreParams{}
+	p.SetContext(ctx)
+	p.SetQueryMsg(string(reqRaw))
+	for contract, metric := range m.Contracts {
+		p.SetContractAddress(contract)
+
+		resp, err := m.apiClient.Wasm.GetWasmContractsContractAddressStore(&p)
+		if err != nil {
+			m.logger.Errorf("failed to process %s request for metric %s: %+v", m.Name(), metric, err)
+			continue
+		}
+
+		data, err := json.Marshal(resp.Payload.Result)
+		if err != nil {
+			m.logger.Errorf("failed to marshal %s: %+v", m.Name(), err)
+		}
+
+		m.metrics[metric] = float64(crc32.ChecksumIEEE(data))
+	}
+	m.logger.Infoln("updated ", m.Name())
+	return nil
+}

--- a/collector/monitors/configs_monitor_test.go
+++ b/collector/monitors/configs_monitor_test.go
@@ -1,0 +1,97 @@
+package monitors
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/lidofinance/terra-monitors/collector/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type DetectorChangesTestSuite struct {
+	suite.Suite
+}
+
+func (suite *DetectorChangesTestSuite) SetupTest() {
+
+}
+
+func (suite *DetectorChangesTestSuite) TestHubParameters() {
+	hubParametersFakeResponse := struct {
+		Height string
+		Result interface{}
+	}{Height: "100",
+		Result: types.HubParameters{
+			EpochPeriod:         10,
+			UnderlyingCoinDenom: "uluna",
+			UnbondingPeriod:     20,
+			PegRecoveryFee:      "0.5",
+			ErThreshold:         "1",
+			RewardDenom:         "uusd",
+		},
+	}
+	responseData, err := json.Marshal(hubParametersFakeResponse)
+	suite.NoError(err)
+	ts := NewServerWithResponse(string(responseData))
+	cfg := NewTestCollectorConfig(ts.URL)
+	hubParametersMonitor := NewHubParametersMonitor(cfg)
+
+	err = hubParametersMonitor.Handler(context.Background())
+	suite.NoError(err)
+	suite.Equal(hubParametersFakeResponse.Result, *hubParametersMonitor.State)
+	crc32first := hubParametersMonitor.metrics[HubParametersCRC32]
+
+	//   changing response data
+	newHubParametersFakeResponse := struct {
+		Height string
+		Result interface{}
+	}{Height: "100",
+		Result: types.HubParameters{
+			EpochPeriod:         100,
+			UnderlyingCoinDenom: "uusd",
+			UnbondingPeriod:     200,
+			PegRecoveryFee:      "1.5",
+			ErThreshold:         "2",
+			RewardDenom:         "uluna",
+		},
+	}
+	responseData, err = json.Marshal(newHubParametersFakeResponse)
+	suite.NoError(err)
+
+	ts = NewServerWithResponse(string(responseData))
+	cfg = NewTestCollectorConfig(ts.URL)
+	hubParametersMonitor = NewHubParametersMonitor(cfg)
+
+	err = hubParametersMonitor.Handler(context.Background())
+	suite.NoError(err)
+	suite.Equal(newHubParametersFakeResponse.Result, *hubParametersMonitor.State)
+
+	crc32second := hubParametersMonitor.metrics[HubParametersCRC32]
+
+	//detects crc32 is changed due to changed parameters data
+	suite.NotEqual(crc32first, crc32second)
+}
+
+func (suite *DetectorChangesTestSuite) TestConfigsMonitor() {
+	ts := NewServerWithRandomJson()
+	cfg := NewTestCollectorConfig(ts.URL)
+	m1 := NewConfigsCRC32Monitor(cfg)
+	savedMetrics := make(map[Metric]float64)
+
+	err := m1.Handler(context.Background())
+	suite.NoError(err)
+	for metric, value := range m1.metrics {
+		savedMetrics[metric] = value
+	}
+	err = m1.Handler(context.Background())
+	suite.NoError(err)
+
+	// since we are getting random data each http request
+	// we should get m1.metrics and savedMetrics from first request differ each other
+	suite.Equal(5, len(m1.metrics))
+	suite.Equal(5, len(savedMetrics))
+	for metric := range m1.metrics {
+		_, found := savedMetrics[metric]
+		suite.True(found)
+		suite.NotEqual(m1.metrics[metric], savedMetrics[metric])
+	}
+}

--- a/collector/monitors/hub_parameters_monitor.go
+++ b/collector/monitors/hub_parameters_monitor.go
@@ -1,0 +1,107 @@
+package monitors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/lidofinance/terra-monitors/collector/config"
+	"github.com/lidofinance/terra-monitors/collector/types"
+	"github.com/lidofinance/terra-monitors/openapi/client"
+	"github.com/lidofinance/terra-monitors/openapi/client/wasm"
+	"github.com/sirupsen/logrus"
+	"hash/crc32"
+	"strconv"
+)
+
+const (
+	HubParametersEpochPeriod     Metric = "hub_parameters_epoch_period"
+	HubParametersUnbondingPeriod Metric = "hub_parameters_unbonding_period"
+	HubParametersPegRecoveryFee  Metric = "hub_parameters_peg_recovery_fee"
+	HubParametersErThreshold     Metric = "hub_parameters_er_threshold"
+	HubParametersCRC32           Metric = "hub_parameters_crc32"
+)
+
+type HubParametersMonitor struct {
+	metrics         map[Metric]float64
+	State           *types.HubParameters
+	ContractAddress string
+	apiClient       *client.TerraLiteForTerra
+	logger          *logrus.Logger
+}
+
+func NewHubParametersMonitor(cfg config.CollectorConfig) HubParametersMonitor {
+	m := HubParametersMonitor{
+		metrics:         make(map[Metric]float64),
+		State:           &types.HubParameters{},
+		ContractAddress: cfg.HubContract,
+		apiClient:       cfg.GetTerraClient(),
+		logger:          cfg.Logger,
+	}
+
+	return m
+}
+
+func (h HubParametersMonitor) Name() string {
+	return "HubParameters"
+}
+
+func (h *HubParametersMonitor) InitMetrics() {
+	h.metrics[HubParametersCRC32] = 0
+	h.metrics[HubParametersEpochPeriod] = 0
+	h.metrics[HubParametersUnbondingPeriod] = 0
+	h.metrics[HubParametersPegRecoveryFee] = 0
+	h.metrics[HubParametersErThreshold] = 0
+}
+
+func (h *HubParametersMonitor) setStringMetric(m Metric, rawValue string) {
+	v, err := strconv.ParseFloat(rawValue, 64)
+	if err != nil {
+		h.logger.Errorf("failed to set value \"%s\" to metric \"%s\": %+v\n", rawValue, m, err)
+	}
+	h.metrics[m] = v
+}
+
+func (h *HubParametersMonitor) updateMetrics() {
+	data, err := json.Marshal(h.State)
+	if err != nil {
+		h.logger.Errorf("failed to marshal %s: %s", h.Name(), err)
+	}
+	h.metrics[HubParametersCRC32] = float64(crc32.ChecksumIEEE(data))
+	h.metrics[HubParametersEpochPeriod] = float64(h.State.EpochPeriod)
+	h.metrics[HubParametersUnbondingPeriod] = float64(h.State.UnbondingPeriod)
+	h.setStringMetric(HubParametersPegRecoveryFee, h.State.PegRecoveryFee)
+	h.setStringMetric(HubParametersErThreshold, h.State.ErThreshold)
+}
+
+func (h *HubParametersMonitor) Handler(ctx context.Context) error {
+	hubReq, hubResp := types.HubParametersRequest{}, types.HubParameters{}
+
+	reqRaw, err := json.Marshal(&hubReq)
+	if err != nil {
+		return fmt.Errorf("failed to marshal HubParameters request: %w", err)
+	}
+
+	p := wasm.GetWasmContractsContractAddressStoreParams{}
+	p.SetContext(ctx)
+	p.SetContractAddress(h.ContractAddress)
+	p.SetQueryMsg(string(reqRaw))
+
+	resp, err := h.apiClient.Wasm.GetWasmContractsContractAddressStore(&p)
+	if err != nil {
+		return fmt.Errorf("failed to process HubParameters request: %w", err)
+	}
+
+	err = types.CastMapToStruct(resp.Payload.Result, &hubResp)
+	if err != nil {
+		return fmt.Errorf("failed to parse HubParameters body interface: %w", err)
+	}
+
+	h.logger.Infoln("updated HubParameters")
+	h.State = &hubResp
+	h.updateMetrics()
+	return nil
+}
+
+func (h HubParametersMonitor) GetMetrics() map[Metric]float64 {
+	return h.metrics
+}

--- a/collector/monitors/monitor_test.go
+++ b/collector/monitors/monitor_test.go
@@ -61,4 +61,5 @@ func TestLocales(t *testing.T) {
 	suite.Run(t, new(MonitorTestSuite))
 	suite.Run(t, new(UpdateGlobalIndexMonitorTestSuite))
 	suite.Run(t, new(SlashingMonitorTestSuite))
+	suite.Run(t, new(DetectorChangesTestSuite))
 }

--- a/collector/monitors/reward_state_monitor.go
+++ b/collector/monitors/reward_state_monitor.go
@@ -20,7 +20,7 @@ var (
 func NewRewardStateMonitor(cfg config.CollectorConfig) RewardStateMonitor {
 	m := RewardStateMonitor{
 		State:           &types.RewardStateResponse{},
-		ContractAddress: cfg.RewardContract,
+		ContractAddress: cfg.BlunaRewardContract,
 		metrics:         make(map[Metric]float64),
 		apiClient:       cfg.GetTerraClient(),
 		logger:          cfg.Logger,

--- a/collector/monitors/reward_state_monitor.go
+++ b/collector/monitors/reward_state_monitor.go
@@ -20,7 +20,7 @@ var (
 func NewRewardStateMonitor(cfg config.CollectorConfig) RewardStateMonitor {
 	m := RewardStateMonitor{
 		State:           &types.RewardStateResponse{},
-		ContractAddress: cfg.BlunaRewardContract,
+		ContractAddress: cfg.RewardContract,
 		metrics:         make(map[Metric]float64),
 		apiClient:       cfg.GetTerraClient(),
 		logger:          cfg.Logger,

--- a/collector/monitors/stubs_test.go
+++ b/collector/monitors/stubs_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -22,12 +23,16 @@ func NewTestCollectorConfig(urlWithScheme string) config.CollectorConfig {
 	host := strings.Split(urlWithScheme, "//")[1]
 	out := bytes.NewBuffer(nil)
 	cfg := config.CollectorConfig{
-		LCDEndpoint:            host,
-		Logger:                 logging.NewDefaultLogger(),
-		HubContract:            "terra1mtwph2juhj0rvjz7dy92gvl6xvukaxu8rfv8ts",
-		RewardContract:         "terra17yap3mhph35pcwvhza38c2lkj7gzywzy05h7l0",
-		BlunaTokenInfoContract: "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
-		Schemes:                []string{"http"},
+		Logger:                      logging.NewDefaultLogger(),
+		LCDEndpoint:                 host,
+		HubContract:                 "terra1mtwph2juhj0rvjz7dy92gvl6xvukaxu8rfv8ts",
+		RewardContract:              "terra17yap3mhph35pcwvhza38c2lkj7gzywzy05h7l0",
+		BlunaTokenInfoContract:      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+		UpdateGlobalIndexBotAddress: "dummy_updateglobalindexbot",
+		RewardDispatcherContract:    "dummy_rewarddispatcher",
+		ValidatorRegistryAddress:    "dummy_validatorsregistry",
+		AirDropRegistryContract:     "dummy_airdropRegistry",
+		Schemes:                     []string{"http"},
 	}
 	cfg.Logger.Out = out
 	return cfg
@@ -65,6 +70,23 @@ func NewServerWithRoutedResponse(routeToResponse map[string]string) *httptest.Se
 	}
 
 	return httptest.NewServer(mux)
+}
+
+func NewServerWithRandomJson() *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		response := make(map[string]interface{})
+		response["height"] = "10000"
+		response["result"] = map[string]int{
+			"data": rand.Int(),
+		}
+		data, err := json.Marshal(response)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Fprintln(w, string(data))
+	}))
+	return ts
 }
 
 func NewServerWithError(errorMessage string) *httptest.Server {

--- a/collector/monitors/whitelisted_validators_monitor.go
+++ b/collector/monitors/whitelisted_validators_monitor.go
@@ -1,0 +1,61 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"github.com/lidofinance/terra-monitors/collector/config"
+	"github.com/lidofinance/terra-monitors/openapi/client"
+	"github.com/sirupsen/logrus"
+	"hash/crc32"
+	"strings"
+)
+
+const (
+	WhitelistedValidatorsCRC32 = "whitelisted_validators_crc32"
+	WhitelistedValidatorsNum   = "whitelisted_validators_num"
+)
+
+type WhitelistedValidatorsMonitor struct {
+	metrics   map[Metric]float64
+	apiClient *client.TerraLiteForTerra
+	logger    *logrus.Logger
+	validatorsRepository ValidatorsRepository
+}
+
+func NewWhitelistedValidatorsMonitor(cfg config.CollectorConfig, repository ValidatorsRepository) WhitelistedValidatorsMonitor {
+	m := WhitelistedValidatorsMonitor{
+		metrics:   make(map[Metric]float64),
+		apiClient: cfg.GetTerraClient(),
+		logger:    cfg.Logger,
+		validatorsRepository: repository,
+	}
+
+	return m
+}
+
+func (m WhitelistedValidatorsMonitor) Name() string {
+	return "WhitelistedValidatorsMonitor"
+}
+
+func (m *WhitelistedValidatorsMonitor) InitMetrics() {
+	m.metrics[WhitelistedValidatorsCRC32] = 0
+	m.metrics[WhitelistedValidatorsNum] = 0
+}
+
+func (m WhitelistedValidatorsMonitor) GetMetrics() map[Metric]float64 {
+	return m.metrics
+}
+
+func (m *WhitelistedValidatorsMonitor) Handler(ctx context.Context) error {
+
+	validators,err := m.validatorsRepository.GetValidatorsAddresses(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get whiltelisted validators for %s: %w",m.Name(), err)
+	}
+
+
+	m.metrics[WhitelistedValidatorsCRC32] = float64(crc32.ChecksumIEEE([]byte(strings.Join(validators,""))))
+	m.metrics[WhitelistedValidatorsNum] = float64(len(validators))
+	m.logger.Infoln("updated ", m.Name())
+	return nil
+}

--- a/collector/types/types.go
+++ b/collector/types/types.go
@@ -64,7 +64,7 @@ type TokenInfoResponse struct {
 //     pub last_processed_batch: u64,
 // }
 
-//should be corrected after contract migration according new response schema
+//should be corrected after contract migration according the new response schema
 
 type HubStateResponse struct {
 	ExchangeRate          string `json:"exchange_rate"`     //decimal

--- a/collector/types/types.go
+++ b/collector/types/types.go
@@ -64,7 +64,7 @@ type TokenInfoResponse struct {
 //     pub last_processed_batch: u64,
 // }
 
-//should be corrected after contract migration according the new response schema
+//should be corrected after contract migration according to the new response schema
 
 type HubStateResponse struct {
 	ExchangeRate          string `json:"exchange_rate"`     //decimal

--- a/collector/types/types.go
+++ b/collector/types/types.go
@@ -64,7 +64,8 @@ type TokenInfoResponse struct {
 //     pub last_processed_batch: u64,
 // }
 
-//shoud be corrtced after contract migration according new response schema
+//should be corrected after contract migration according new response schema
+
 type HubStateResponse struct {
 	ExchangeRate          string `json:"exchange_rate"`     //decimal
 	TotalBondAmount       string `json:"total_bond_amount"` //uint128
@@ -89,4 +90,56 @@ type HubWhitelistedValidatorsResponse struct {
 
 func GetHubWhitelistedValidatorsPair() (HubWhitelistedValidatorsRequest, HubWhitelistedValidatorsResponse) {
 	return HubWhitelistedValidatorsRequest{}, HubWhitelistedValidatorsResponse{}
+}
+
+type HubConfig struct {
+	Creator                    string `json:"creator"`
+	RewardDispatcherContract   string `json:"reward_dispatcher_contract"`
+	ValidatorsRegistryContract string `json:"validators_registry_contract"`
+	BlunaTokenContract         string `json:"bluna_token_contract"`
+	StlunaTokenContract        string `json:"stluna_token_contract"`
+	AirdropRegistryContract    string `json:"airdrop_registry_contract"`
+}
+
+type CommonConfigRequest struct {
+	Config struct{} `json:"config"`
+}
+
+type HubParameters struct {
+	EpochPeriod         uint64 `json:"epoch_period"`
+	UnderlyingCoinDenom string `json:"underlying_coin_denom"`
+	UnbondingPeriod     uint64 `json:"unbonding_period"`
+	PegRecoveryFee      string `json:"peg_recovery_fee"` //Decimal128 as string
+	ErThreshold         string `json:"er_threshold"`     //Decimal128 as string
+	RewardDenom         string `json:"reward_denom"`
+}
+
+type HubParametersRequest struct {
+	Parameters struct{} `json:"parameters"`
+}
+
+type BlunaRewardConfig struct {
+	HubContract string `json:"hub_contract"`
+	RewardDenom string `json:"reward_denom"`
+}
+
+type RewardDispatcherConfig struct {
+	Owner               string `json:"owner"`
+	HubContract         string `json:"hub_contract"`
+	BlunaRewardContract string `json:"bluna_reward_contract"`
+	StlunaRewardDenom   string `json:"stluna_reward_denom"`
+	BlunaRewardDenom    string `json:"bluna_reward_denom"`
+	LidoFeeAddress      string `json:"lido_fee_address"`
+	LidoFeeRate         string `json:"lido_fee_rate"` //decimal128
+}
+
+type ValidatorsRegistryConfig struct {
+	Owner       string `json:"owner"`
+	HubContract string `json:"hub_contract"`
+}
+
+type AirDropRegistryConfig struct {
+	Owner       string `json:"owner"`
+	HubContract string `json:"hub_contract"`
+	AirDropToken []string `json:"airdrop_tokens"`
 }

--- a/docker/config/grafana/provisioning/dashboards/lido_basset/lido_basset.json
+++ b/docker/config/grafana/provisioning/dashboards/lido_basset/lido_basset.json
@@ -110,7 +110,132 @@
         "x": 0,
         "y": 0
       },
-      "id": 12,
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "bluna_reward_config_crc32{}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "hub_config_crc32{}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "hub_parameters_crc32{}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "reward_dispatcher_config_crc32{}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "D"
+        },
+        {
+          "exemplar": true,
+          "expr": "validators_registry_config_crc32{}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "E"
+        },
+        {
+          "hide": false,
+          "refId": "F"
+        },
+        {
+          "exemplar": true,
+          "expr": "airdrop_registry_config_crc32{}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "G"
+        }
+      ],
+      "title": "configs crc32",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
       "options": {
         "legend": {
           "calcs": [],
@@ -215,7 +340,6 @@
       "title": "Slashing: Missed Blocks",
       "type": "timeseries"
     },
-    {
     {
       "alert": {
         "alertRuleTags": {},

--- a/docker/config/grafana/provisioning/dashboards/lido_basset/lido_basset.json
+++ b/docker/config/grafana/provisioning/dashboards/lido_basset/lido_basset.json
@@ -18,14 +18,27 @@
   "links": [],
   "panels": [
     {
-<<<<<<< HEAD
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 24,
+      "panels": [],
+      "title": "contracts parameters monitoring",
+      "type": "row"
+    },
+    {
       "alert": {
         "alertRuleTags": {},
         "conditions": [
           {
             "evaluator": {
               "params": [
-                0.0
+                0
               ],
               "type": "gt"
             },
@@ -41,33 +54,42 @@
             },
             "reducer": {
               "params": [],
-              "type": "avg"
+              "type": "diff_abs"
+            },
+            "type": "query"
+          },
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "or"
+            },
+            "query": {
+              "params": [
+                "B",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "diff_abs"
             },
             "type": "query"
           }
         ],
-        "executionErrorState": "keep_state",
-        "for": "2m",
-        "frequency": "30s",
+        "executionErrorState": "alerting",
+        "for": "5m",
+        "frequency": "1m",
         "handler": 1,
-        "name": "Bluna/luna exchange rate out of range",
+        "name": "Hub parameters epoch/unbinding period has been changed",
         "noDataState": "no_data",
         "notifications": []
       },
-      "collapsed": false,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 12,
-      "panels": [],
-      "title": "Hub parameters",
-      "type": "row"
-    },
-    {
       "datasource": null,
       "fieldConfig": {
         "defaults": {
@@ -125,7 +147,7 @@
         "x": 0,
         "y": 1
       },
-      "id": 8,
+      "id": 14,
       "options": {
         "legend": {
           "calcs": [],
@@ -150,391 +172,56 @@
           "hide": false,
           "interval": "",
           "legendFormat": "Unbonding period",
-          "refId": "E"
+          "refId": "B"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "op": "gt",
+          "value": 0,
+          "visible": true
         }
       ],
       "title": "Hub parameters",
       "type": "timeseries"
     },
     {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
             },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
+            "operator": {
+              "type": "and"
             },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
             },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
+            "reducer": {
+              "params": [],
+              "type": "diff_abs"
+            },
+            "type": "query"
           }
-        },
-        "overrides": []
+        ],
+        "executionErrorState": "alerting",
+        "for": "5m",
+        "frequency": "1m",
+        "handler": 1,
+        "name": "Hub er threshold has been changed",
+        "noDataState": "no_data",
+        "notifications": []
       },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 1
-      },
-      "id": 14,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "hub_parameters_er_threshold{}",
-          "interval": "",
-          "legendFormat": "Er threshold",
-          "refId": "A"
-        }
-      ],
-      "title": "Er threshold hub parameter",
-      "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 9
-      },
-      "id": 16,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "hub_parameters_peg_recovery_fee{}",
-          "interval": "",
-          "legendFormat": "Peg recovery fee",
-          "refId": "A"
-        }
-      ],
-      "title": "Peg recovery fee hub parameter",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 17
-      },
-      "id": 10,
-      "panels": [],
-      "title": "Row title",
-      "type": "row"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 18
-      },
-      "id": 6,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "bluna_reward_config_crc32{}",
-          "interval": "",
-          "legendFormat": "bluna reward config crc32",
-          "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "hub_config_crc32{}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "hub config crc32",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "hub_parameters_crc32{}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "hub parameters crc32",
-          "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "reward_dispatcher_config_crc32{}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "reward dispatcher config crc32",
-          "refId": "D"
-        },
-        {
-          "exemplar": true,
-          "expr": "validators_registry_config_crc32{}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "validators registry config crc32",
-          "refId": "E"
-        },
-        {
-          "exemplar": true,
-          "expr": "airdrop_registry_config_crc32{}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "airdrop registry config crc32",
-          "refId": "G"
-        }
-      ],
-      "title": "configs crc32",
-      "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 18
-      },
-      "id": 4,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "slashing_num_jailed_validators{}",
-          "interval": "",
-          "legendFormat": "currently jailed validators",
-          "refId": "A"
-        }
-      ],
-      "title": "Slashing: Jailed Validators",
-      "type": "timeseries"
-    },
-    {
       "datasource": null,
       "fieldConfig": {
         "defaults": {
@@ -590,9 +277,9 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 0
+        "y": 1
       },
-      "id": 10,
+      "id": 16,
       "options": {
         "legend": {
           "calcs": [],
@@ -606,14 +293,21 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "slashing_num_missed_blocks{}",
-          "hide": false,
+          "expr": "hub_parameters_er_threshold{}",
           "interval": "",
-          "legendFormat": "number of missed blocks (all validators)",
-          "refId": "C"
+          "legendFormat": "Er threshold",
+          "refId": "A"
         }
       ],
-      "title": "Slashing: Missed Blocks",
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "op": "gt",
+          "value": 0,
+          "visible": true
+        }
+      ],
+      "title": "Hub er threshold",
       "type": "timeseries"
     },
     {
@@ -623,7 +317,7 @@
           {
             "evaluator": {
               "params": [
-                0.0
+                0
               ],
               "type": "gt"
             },
@@ -639,16 +333,16 @@
             },
             "reducer": {
               "params": [],
-              "type": "avg"
+              "type": "diff"
             },
             "type": "query"
           }
         ],
-        "executionErrorState": "keep_state",
-        "for": "2m",
-        "frequency": "30s",
+        "executionErrorState": "alerting",
+        "for": "5m",
+        "frequency": "1m",
         "handler": 1,
-        "name": "Bluna/luna exchange rate out of range",
+        "name": "Hub peg recovery has been changed",
         "noDataState": "no_data",
         "notifications": []
       },
@@ -707,9 +401,9 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 0
+        "y": 1
       },
-      "id": 8,
+      "id": 18,
       "options": {
         "legend": {
           "calcs": [],
@@ -723,10 +417,640 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "slashing_num_tombstoned_validators{}",
+          "expr": "hub_parameters_peg_recovery_fee{}",
           "interval": "",
-          "legendFormat": "currently tombstoned validators",
+          "legendFormat": "Peg recovery fee",
           "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "op": "gt",
+          "value": 0,
+          "visible": true
+        }
+      ],
+      "title": "Hub peg recovery fee",
+      "type": "timeseries"
+    },
+    {
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "diff_abs"
+            },
+            "type": "query"
+          },
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "or"
+            },
+            "query": {
+              "params": [
+                "B",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "diff_abs"
+            },
+            "type": "query"
+          },
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "or"
+            },
+            "query": {
+              "params": [
+                "C",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "diff_abs"
+            },
+            "type": "query"
+          },
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "or"
+            },
+            "query": {
+              "params": [
+                "D",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "diff_abs"
+            },
+            "type": "query"
+          },
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "or"
+            },
+            "query": {
+              "params": [
+                "E",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "diff_abs"
+            },
+            "type": "query"
+          },
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "or"
+            },
+            "query": {
+              "params": [
+                "F",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "diff_abs"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "alerting",
+        "for": "5m",
+        "frequency": "1m",
+        "handler": 1,
+        "name": "one of the configs has been changed",
+        "noDataState": "no_data",
+        "notifications": []
+      },
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "airdrop_registry_config_crc32",
+          "interval": "",
+          "legendFormat": "airdrop registry config",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "bluna_reward_config_crc32{}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "bluna reward config",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "hub_config_crc32{}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "hub config",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "hub_parameters_crc32{}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "hub parameters",
+          "refId": "D"
+        },
+        {
+          "exemplar": true,
+          "expr": "reward_dispatcher_config_crc32{}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "reward dispatcher config",
+          "refId": "E"
+        },
+        {
+          "exemplar": true,
+          "expr": "validators_registry_config_crc32{}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "validators registry config",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "op": "gt",
+          "value": 0,
+          "visible": true
+        }
+      ],
+      "title": "crc32 sums of config data",
+      "type": "timeseries"
+    },
+    {
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "diff_abs"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "keep_state",
+        "for": "5m",
+        "frequency": "1m",
+        "handler": 1,
+        "name": "Whitelisted validators set has been changed",
+        "noDataState": "no_data",
+        "notifications": []
+      },
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "whitelisted_validators_crc32{}",
+          "interval": "",
+          "legendFormat": "whitelisted validators crc32",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "op": "gt",
+          "value": 0,
+          "visible": true
+        }
+      ],
+      "title": "Whitelisted validators CRC32",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "whitelisted_validators_num",
+          "interval": "",
+          "legendFormat": "number of whitelisted validators",
+          "refId": "A"
+        }
+      ],
+      "title": "Number of whitelisted validators",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 22,
+      "panels": [],
+      "title": "contracts state monitoring",
+      "type": "row"
+    },
+    {
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "keep_state",
+        "for": "2m",
+        "frequency": "30s",
+        "handler": 1,
+        "name": "Some validators were jailed.",
+        "noDataState": "no_data",
+        "notifications": []
+      },
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "slashing_num_jailed_validators{}",
+          "interval": "",
+          "legendFormat": "currently jailed validators",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "op": "gt",
+          "value": 0,
+          "visible": true
         }
       ],
       "title": "Slashing: Jailed Validators",
@@ -787,10 +1111,10 @@
       "gridPos": {
         "h": 8,
         "w": 8,
-        "x": 0,
-        "y": 8
+        "x": 8,
+        "y": 18
       },
-      "id": 6,
+      "id": 10,
       "options": {
         "legend": {
           "calcs": [],
@@ -804,30 +1128,138 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "update_global_index_gas_used{}",
+          "expr": "slashing_num_missed_blocks{}",
           "hide": false,
           "interval": "",
-          "legendFormat": "gas used",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "update_global_index_gas_wanted{}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "gas wanted",
+          "legendFormat": "number of missed blocks (all validators)",
           "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "update_global_index_uusd_fee{}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "uusd fee",
-          "refId": "E"
         }
       ],
-      "title": "update global index fees",
+      "title": "Slashing: Missed Blocks",
+      "type": "timeseries"
+    },
+    {
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "keep_state",
+        "for": "2m",
+        "frequency": "30s",
+        "handler": 1,
+        "name": "Found tombstoned validators",
+        "noDataState": "no_data",
+        "notifications": []
+      },
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "slashing_num_tombstoned_validators{}",
+          "interval": "",
+          "legendFormat": "currently tombstoned validators",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "op": "gt",
+          "value": 0,
+          "visible": true
+        }
+      ],
+      "title": "Slashing: Tombstoned Validators",
       "type": "timeseries"
     },
     {
@@ -885,8 +1317,141 @@
       "gridPos": {
         "h": 8,
         "w": 8,
+        "x": 0,
+        "y": 26
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "update_global_index_gas_used{}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "gas used",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "update_global_index_gas_wanted{}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "gas wanted",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "update_global_index_uusd_fee{}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "uusd fee",
+          "refId": "E"
+        }
+      ],
+      "title": "update global index fees",
+      "type": "timeseries"
+    },
+    {
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "max"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "keep_state",
+        "for": "5m",
+        "frequency": "1m",
+        "handler": 1,
+        "name": "update global index bot failed transactions",
+        "noDataState": "ok",
+        "notifications": []
+      },
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
         "x": 8,
-        "y": 8
+        "y": 26
       },
       "id": 4,
       "options": {
@@ -896,7 +1461,7 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "multi"
         }
       },
       "targets": [
@@ -914,6 +1479,14 @@
           "interval": "",
           "legendFormat": "successful txs since last check",
           "refId": "B"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "op": "gt",
+          "value": 0,
+          "visible": true
         }
       ],
       "title": "update global index transactions",
@@ -1007,12 +1580,10 @@
         "overrides": []
       },
       "gridPos": {
-
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 8
-
+        "y": 26
       },
       "id": 2,
       "options": {
@@ -1060,7 +1631,7 @@
     "list": []
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},

--- a/docker/config/grafana/provisioning/dashboards/lido_basset/lido_basset.json
+++ b/docker/config/grafana/provisioning/dashboards/lido_basset/lido_basset.json
@@ -18,6 +18,7 @@
   "links": [],
   "panels": [
     {
+<<<<<<< HEAD
       "alert": {
         "alertRuleTags": {},
         "conditions": [
@@ -53,6 +54,20 @@
         "noDataState": "no_data",
         "notifications": []
       },
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Hub parameters",
+      "type": "row"
+    },
+    {
       "datasource": null,
       "fieldConfig": {
         "defaults": {
@@ -108,7 +123,272 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 0
+        "y": 1
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "hub_parameters_epoch_period{}",
+          "interval": "",
+          "legendFormat": "Epoch period",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "hub_parameters_unbonding_period{}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Unbonding period",
+          "refId": "E"
+        }
+      ],
+      "title": "Hub parameters",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "hub_parameters_er_threshold{}",
+          "interval": "",
+          "legendFormat": "Er threshold",
+          "refId": "A"
+        }
+      ],
+      "title": "Er threshold hub parameter",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "hub_parameters_peg_recovery_fee{}",
+          "interval": "",
+          "legendFormat": "Peg recovery fee",
+          "refId": "A"
+        }
+      ],
+      "title": "Peg recovery fee hub parameter",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Row title",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
       },
       "id": 6,
       "options": {
@@ -118,7 +398,7 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "multi"
         }
       },
       "targets": [
@@ -126,7 +406,7 @@
           "exemplar": true,
           "expr": "bluna_reward_config_crc32{}",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "bluna reward config crc32",
           "refId": "A"
         },
         {
@@ -134,7 +414,7 @@
           "expr": "hub_config_crc32{}",
           "hide": false,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "hub config crc32",
           "refId": "B"
         },
         {
@@ -142,7 +422,7 @@
           "expr": "hub_parameters_crc32{}",
           "hide": false,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "hub parameters crc32",
           "refId": "C"
         },
         {
@@ -150,7 +430,7 @@
           "expr": "reward_dispatcher_config_crc32{}",
           "hide": false,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "reward dispatcher config crc32",
           "refId": "D"
         },
         {
@@ -158,19 +438,15 @@
           "expr": "validators_registry_config_crc32{}",
           "hide": false,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "validators registry config crc32",
           "refId": "E"
-        },
-        {
-          "hide": false,
-          "refId": "F"
         },
         {
           "exemplar": true,
           "expr": "airdrop_registry_config_crc32{}",
           "hide": false,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "airdrop registry config crc32",
           "refId": "G"
         }
       ],
@@ -233,7 +509,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 18
       },
       "id": 4,
       "options": {
@@ -731,10 +1007,12 @@
         "overrides": []
       },
       "gridPos": {
+
         "h": 8,
         "w": 8,
         "x": 16,
         "y": 8
+
       },
       "id": 2,
       "options": {

--- a/docker/config/prometheus/prometheus.yml
+++ b/docker/config/prometheus/prometheus.yml
@@ -1,10 +1,11 @@
 # my global config
 global:
-  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  scrape_interval:     1m # Set the scrape interval to every 15 seconds. Default is every 1 minute.
   evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  scrape_timeout: 30s
 
 scrape_configs:
   - job_name: lido_terra
-    scrape_interval: 20s
+    scrape_interval: 1m
     static_configs:
     - targets: ['lido_terra:8080']

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -50,13 +50,13 @@ func (p *PromExtractor) updateGaugeValue(name monitors.Metric) error {
 }
 
 func (p PromExtractor) UpdateMetrics(ctx context.Context) {
-	err := p.collector.UpdateData(ctx)
-	if err != nil {
+	errors := p.collector.UpdateData(ctx)
+	for _,err := range errors {
 		p.log.Errorf("failed to update collector data: %v", err)
 	}
 
 	for _, gaugeName := range p.GaugeMetrics {
-		err = p.updateGaugeValue(gaugeName)
+		err := p.updateGaugeValue(gaugeName)
 		if err != nil {
 			p.log.Errorf("failed to update gauge value \"%s\": %v", gaugeName, err)
 		}

--- a/main.go
+++ b/main.go
@@ -33,6 +33,12 @@ func createCollector() collector.LCDCollector {
 	updateGlobalIndexMonitor := monitors.NewUpdateGlobalIndexMonitor(defConfig)
 	c.RegisterMonitor(&updateGlobalIndexMonitor)
 
+	hubParameters := monitors.NewHubParametersMonitor(defConfig)
+	c.RegisterMonitor(&hubParameters)
+
+	configCRC32Monitor := monitors.NewConfigsCRC32Monitor(defConfig)
+	c.RegisterMonitor(&configCRC32Monitor)
+
 	return c
 }
 

--- a/main.go
+++ b/main.go
@@ -39,6 +39,9 @@ func createCollector() collector.LCDCollector {
 	configCRC32Monitor := monitors.NewConfigsCRC32Monitor(defConfig)
 	c.RegisterMonitor(&configCRC32Monitor)
 
+	whitelistedValidatorsMonitor := monitors.NewWhitelistedValidatorsMonitor(defConfig,validatorsRepository)
+	c.RegisterMonitor(&whitelistedValidatorsMonitor)
+
 	return c
 }
 


### PR DESCRIPTION
PR adds the following metrics to grafana panel
```
airdrop_registry_config_crc32  
validators_registry_config_crc32
reward_dispatcher_config_crc32
hub_parameters_crc32
hub_config_crc32
bluna_reward_config_crc32
```

each metric represents crc32 checksum of config data we are getting by request to LCD https://fcd.terra.dev/wasm/contracts/{{contract_address}}/store?query_msg={"config":{}}
where {{contract_address}} is a contract address  for config we are looking for.
this is a response example for hub contract
```json
{
  "height": "3943526",
  "result": {
    "owner": "terra19agehpmaxwcufyvyr87kqc9q27wrchua9tu0uc",
    "reward_contract": "terra17yap3mhph35pcwvhza38c2lkj7gzywzy05h7l0",
    "token_contract": "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
    "airdrop_registry_contract": null
  }
}
```
for now we have no airdrop_registry, validators_registry and reward_dispatcher addresses so appropriate crc32 values are equals to zero.