### PR TITLE
feat: labeled metrics

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -12,23 +12,27 @@ import (
 
 type Collector interface {
 	Get(metric monitors.Metric) (float64, error)
+	GetVector(metric monitors.Metric) (map[string]float64, error)
 	ProvidedMetrics() []monitors.Metric
+	ProvidedMetricVectors() []monitors.Metric
 	UpdateData(ctx context.Context) []error
 }
 
 func NewLCDCollector(cfg config.CollectorConfig) LCDCollector {
 	return LCDCollector{
-		Metrics:   make(map[monitors.Metric]monitors.Monitor),
-		logger:    cfg.Logger,
-		apiClient: cfg.GetTerraClient(),
+		Metrics:       make(map[monitors.Metric]monitors.Monitor),
+		MetricVectors: make(map[monitors.Metric]monitors.Monitor),
+		logger:        cfg.Logger,
+		apiClient:     cfg.GetTerraClient(),
 	}
 }
 
 type LCDCollector struct {
-	Metrics   map[monitors.Metric]monitors.Monitor
-	Monitors  []monitors.Monitor
-	logger    *logrus.Logger
-	apiClient *client.TerraLiteForTerra
+	Metrics       map[monitors.Metric]monitors.Monitor
+	MetricVectors map[monitors.Metric]monitors.Monitor
+	Monitors      []monitors.Monitor
+	logger        *logrus.Logger
+	apiClient     *client.TerraLiteForTerra
 }
 
 func (c LCDCollector) GetApiClient() *client.TerraLiteForTerra {
@@ -47,12 +51,28 @@ func (c LCDCollector) ProvidedMetrics() []monitors.Metric {
 	return metrics
 }
 
+func (c LCDCollector) ProvidedMetricVectors() []monitors.Metric {
+	var metrics []monitors.Metric
+	for m := range c.MetricVectors {
+		metrics = append(metrics, m)
+	}
+	return metrics
+}
+
 func (c LCDCollector) Get(metric monitors.Metric) (float64, error) {
 	monitor, found := c.Metrics[metric]
 	if !found {
 		return 0, fmt.Errorf("monitor for metric \"%s\" not found", metric)
 	}
 	return monitor.GetMetrics()[metric], nil
+}
+
+func (c LCDCollector) GetVector(metric monitors.Metric) (map[string]float64, error) {
+	monitor, found := c.MetricVectors[metric]
+	if !found {
+		return nil, fmt.Errorf("monitor for metric vector \"%s\" not found", metric)
+	}
+	return monitor.GetMetricVectors()[metric], nil
 }
 
 func (c *LCDCollector) UpdateData(ctx context.Context) []error {
@@ -62,7 +82,7 @@ func (c *LCDCollector) UpdateData(ctx context.Context) []error {
 		if err != nil {
 			// one error is not a reason to stop collecting data
 			// collecting monitors errors to return them to calling code
-			errors = append(errors,fmt.Errorf("failed to update data: %w", err))
+			errors = append(errors, fmt.Errorf("failed to update data: %w", err))
 		}
 	}
 	return errors
@@ -76,6 +96,13 @@ func (c *LCDCollector) RegisterMonitor(m monitors.Monitor) {
 		}
 
 		c.Metrics[metric] = m
+	}
+	for metric := range m.GetMetricVectors() {
+		if wantedMonitor, found := c.MetricVectors[metric]; found {
+			panic(fmt.Sprintf("register monitor %s failed. metrics collision. Monitor %s has declared metric %s", m.Name(), wantedMonitor.Name(), metric))
+		}
+
+		c.MetricVectors[metric] = m
 	}
 	c.Monitors = append(c.Monitors, m)
 }

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -88,7 +88,7 @@ func (c *LCDCollector) UpdateData(ctx context.Context) []error {
 	return errors
 }
 
-func mapsContains(key monitors.Metric, maps ...map[monitors.Metric]monitors.Monitor) (monitors.Monitor, bool) {
+func findMaps(key monitors.Metric, maps ...map[monitors.Metric]monitors.Monitor) (monitors.Monitor, bool) {
 	for _, m := range maps {
 		if wantedMonitor, found := m[key]; found {
 			return wantedMonitor, true
@@ -100,14 +100,14 @@ func mapsContains(key monitors.Metric, maps ...map[monitors.Metric]monitors.Moni
 func (c *LCDCollector) RegisterMonitor(m monitors.Monitor) {
 	m.InitMetrics()
 	for metric := range m.GetMetrics() {
-		if wantedMonitor, found := mapsContains(metric, c.Metrics, c.MetricVectors); found {
+		if wantedMonitor, found := findMaps(metric, c.Metrics, c.MetricVectors); found {
 			panic(fmt.Sprintf("register monitor %s failed. metrics collision. Monitor %s has declared metric %s", m.Name(), wantedMonitor.Name(), metric))
 		}
 
 		c.Metrics[metric] = m
 	}
 	for metric := range m.GetMetricVectors() {
-		if wantedMonitor, found := mapsContains(metric, c.Metrics, c.MetricVectors); found {
+		if wantedMonitor, found := findMaps(metric, c.Metrics, c.MetricVectors); found {
 			panic(fmt.Sprintf("register monitor %s failed. metrics collision. Monitor %s has declared metric %s", m.Name(), wantedMonitor.Name(), metric))
 		}
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -15,7 +15,7 @@ type Collector interface {
 	GetVector(metric monitors.MetricName) (monitors.MetricVector, error)
 	ProvidedMetrics() []monitors.MetricName
 	ProvidedMetricVectors() []monitors.MetricName
-	UpdateData(ctx context.Context) error
+	UpdateData(ctx context.Context) []error
 }
 
 func NewLCDCollector(cfg config.CollectorConfig) LCDCollector {

--- a/collector/monitors/bluna_token_info_monitor.go
+++ b/collector/monitors/bluna_token_info_monitor.go
@@ -14,14 +14,14 @@ import (
 )
 
 var (
-	BlunaTotalSupply Metric = "bluna_total_supply"
+	BlunaTotalSupply MetricName = "bluna_total_supply"
 )
 
 func NewBlunaTokenInfoMonitor(cfg config.CollectorConfig) BlunaTokenInfoMonitor {
 	m := BlunaTokenInfoMonitor{
 		State:           &types.TokenInfoResponse{},
 		ContractAddress: cfg.BlunaTokenInfoContract,
-		metrics:         make(map[Metric]float64),
+		metrics:         make(map[MetricName]float64),
 		apiClient:       cfg.GetTerraClient(),
 		logger:          cfg.Logger,
 	}
@@ -31,7 +31,7 @@ func NewBlunaTokenInfoMonitor(cfg config.CollectorConfig) BlunaTokenInfoMonitor 
 type BlunaTokenInfoMonitor struct {
 	State           *types.TokenInfoResponse
 	ContractAddress string
-	metrics         map[Metric]float64
+	metrics         map[MetricName]float64
 	apiClient       *client.TerraLiteForTerra
 	logger          *logrus.Logger
 }
@@ -77,7 +77,7 @@ func (h *BlunaTokenInfoMonitor) Handler(ctx context.Context) error {
 	return nil
 }
 
-func (h *BlunaTokenInfoMonitor) setStringMetric(m Metric, rawValue string) {
+func (h *BlunaTokenInfoMonitor) setStringMetric(m MetricName, rawValue string) {
 	v, err := strconv.ParseFloat(rawValue, 64)
 	if err != nil {
 		h.logger.Errorf("failed to set value \"%s\" to metric \"%s\": %+v\n", rawValue, m, err)
@@ -85,11 +85,11 @@ func (h *BlunaTokenInfoMonitor) setStringMetric(m Metric, rawValue string) {
 	h.metrics[m] = v
 }
 
-func (h BlunaTokenInfoMonitor) GetMetrics() map[Metric]float64 {
+func (h BlunaTokenInfoMonitor) GetMetrics() map[MetricName]float64 {
 	return h.metrics
 }
 
-func (h BlunaTokenInfoMonitor) GetMetricVectors() map[Metric]map[string]float64 {
+func (h BlunaTokenInfoMonitor) GetMetricVectors() map[MetricName]MetricVector {
 	return nil
 }
 

--- a/collector/monitors/bluna_token_info_monitor.go
+++ b/collector/monitors/bluna_token_info_monitor.go
@@ -89,6 +89,10 @@ func (h BlunaTokenInfoMonitor) GetMetrics() map[Metric]float64 {
 	return h.metrics
 }
 
+func (h BlunaTokenInfoMonitor) GetMetricVectors() map[Metric]map[string]float64 {
+	return nil
+}
+
 func (h *BlunaTokenInfoMonitor) SetApiClient(client *client.TerraLiteForTerra) {
 	h.apiClient = client
 }

--- a/collector/monitors/configs_monitor.go
+++ b/collector/monitors/configs_monitor.go
@@ -13,30 +13,30 @@ import (
 )
 
 const (
-	AirDropRegistryConfigCRC32    Metric = "airdrop_registry_config_crc32"
-	BlunaRewardConfigCRC32        Metric = "bluna_reward_config_crc32"
-	HubConfigCRC32                Metric = "hub_config_crc32"
-	RewardDispatcherConfigCRC32   Metric = "reward_dispatcher_config_crc32"
-	ValidatorsRegistryConfigCRC32 Metric = "validators_registry_config_crc32"
+	AirDropRegistryConfigCRC32    MetricName = "airdrop_registry_config_crc32"
+	BlunaRewardConfigCRC32        MetricName = "bluna_reward_config_crc32"
+	HubConfigCRC32                MetricName = "hub_config_crc32"
+	RewardDispatcherConfigCRC32   MetricName = "reward_dispatcher_config_crc32"
+	ValidatorsRegistryConfigCRC32 MetricName = "validators_registry_config_crc32"
 )
 
 type ConfigsCRC32Monitor struct {
-	Contracts map[string]Metric
-	metrics   map[Metric]float64
+	Contracts map[string]MetricName
+	metrics   map[MetricName]float64
 	apiClient *client.TerraLiteForTerra
 	logger    *logrus.Logger
 }
 
 func NewConfigsCRC32Monitor(cfg config.CollectorConfig) ConfigsCRC32Monitor {
 	m := ConfigsCRC32Monitor{
-		Contracts: map[string]Metric{
+		Contracts: map[string]MetricName{
 			cfg.AirDropRegistryContract:  AirDropRegistryConfigCRC32,
 			cfg.ValidatorRegistryAddress: ValidatorsRegistryConfigCRC32,
 			cfg.RewardDispatcherContract: RewardDispatcherConfigCRC32,
 			cfg.HubContract:              HubConfigCRC32,
 			cfg.RewardContract:           BlunaRewardConfigCRC32,
 		},
-		metrics:   make(map[Metric]float64),
+		metrics:   make(map[MetricName]float64),
 		apiClient: cfg.GetTerraClient(),
 		logger:    cfg.Logger,
 	}
@@ -56,8 +56,12 @@ func (m *ConfigsCRC32Monitor) InitMetrics() {
 	m.metrics[BlunaRewardConfigCRC32] = 0
 }
 
-func (m ConfigsCRC32Monitor) GetMetrics() map[Metric]float64 {
+func (m ConfigsCRC32Monitor) GetMetrics() map[MetricName]float64 {
 	return m.metrics
+}
+
+func (m ConfigsCRC32Monitor) GetMetricVectors() map[MetricName]MetricVector {
+	return nil
 }
 
 func (m *ConfigsCRC32Monitor) Handler(ctx context.Context) error {

--- a/collector/monitors/configs_monitor_test.go
+++ b/collector/monitors/configs_monitor_test.go
@@ -75,7 +75,7 @@ func (suite *DetectorChangesTestSuite) TestConfigsMonitor() {
 	ts := NewServerWithRandomJson()
 	cfg := NewTestCollectorConfig(ts.URL)
 	m1 := NewConfigsCRC32Monitor(cfg)
-	savedMetrics := make(map[Metric]float64)
+	savedMetrics := make(map[MetricName]float64)
 
 	err := m1.Handler(context.Background())
 	suite.NoError(err)

--- a/collector/monitors/hub_parameters_monitor.go
+++ b/collector/monitors/hub_parameters_monitor.go
@@ -109,4 +109,3 @@ func (h HubParametersMonitor) GetMetrics() map[MetricName]float64 {
 func (m HubParametersMonitor) GetMetricVectors() map[MetricName]MetricVector {
 	return nil
 }
-

--- a/collector/monitors/hub_parameters_monitor.go
+++ b/collector/monitors/hub_parameters_monitor.go
@@ -14,15 +14,15 @@ import (
 )
 
 const (
-	HubParametersEpochPeriod     Metric = "hub_parameters_epoch_period"
-	HubParametersUnbondingPeriod Metric = "hub_parameters_unbonding_period"
-	HubParametersPegRecoveryFee  Metric = "hub_parameters_peg_recovery_fee"
-	HubParametersErThreshold     Metric = "hub_parameters_er_threshold"
-	HubParametersCRC32           Metric = "hub_parameters_crc32"
+	HubParametersEpochPeriod     MetricName = "hub_parameters_epoch_period"
+	HubParametersUnbondingPeriod MetricName = "hub_parameters_unbonding_period"
+	HubParametersPegRecoveryFee  MetricName = "hub_parameters_peg_recovery_fee"
+	HubParametersErThreshold     MetricName = "hub_parameters_er_threshold"
+	HubParametersCRC32           MetricName = "hub_parameters_crc32"
 )
 
 type HubParametersMonitor struct {
-	metrics         map[Metric]float64
+	metrics         map[MetricName]float64
 	State           *types.HubParameters
 	ContractAddress string
 	apiClient       *client.TerraLiteForTerra
@@ -31,7 +31,7 @@ type HubParametersMonitor struct {
 
 func NewHubParametersMonitor(cfg config.CollectorConfig) HubParametersMonitor {
 	m := HubParametersMonitor{
-		metrics:         make(map[Metric]float64),
+		metrics:         make(map[MetricName]float64),
 		State:           &types.HubParameters{},
 		ContractAddress: cfg.HubContract,
 		apiClient:       cfg.GetTerraClient(),
@@ -53,7 +53,7 @@ func (h *HubParametersMonitor) InitMetrics() {
 	h.metrics[HubParametersErThreshold] = 0
 }
 
-func (h *HubParametersMonitor) setStringMetric(m Metric, rawValue string) {
+func (h *HubParametersMonitor) setStringMetric(m MetricName, rawValue string) {
 	v, err := strconv.ParseFloat(rawValue, 64)
 	if err != nil {
 		h.logger.Errorf("failed to set value \"%s\" to metric \"%s\": %+v\n", rawValue, m, err)
@@ -102,6 +102,11 @@ func (h *HubParametersMonitor) Handler(ctx context.Context) error {
 	return nil
 }
 
-func (h HubParametersMonitor) GetMetrics() map[Metric]float64 {
+func (h HubParametersMonitor) GetMetrics() map[MetricName]float64 {
 	return h.metrics
 }
+
+func (m HubParametersMonitor) GetMetricVectors() map[MetricName]MetricVector {
+	return nil
+}
+

--- a/collector/monitors/hub_state_monitor.go
+++ b/collector/monitors/hub_state_monitor.go
@@ -14,15 +14,15 @@ import (
 )
 
 var (
-	BlunaBondedAmount Metric = "bluna_bonded_amount"
-	BlunaExchangeRate Metric = "bluna_exchange_rate"
+	BlunaBondedAmount MetricName = "bluna_bonded_amount"
+	BlunaExchangeRate MetricName = "bluna_exchange_rate"
 )
 
 func NewHubStateMonitor(cfg config.CollectorConfig) HubStateMonitor {
 	m := HubStateMonitor{
 		State:      &types.HubStateResponse{},
 		HubAddress: cfg.HubContract,
-		metrics:    make(map[Metric]float64),
+		metrics:    make(map[MetricName]float64),
 		apiClient:  cfg.GetTerraClient(),
 		logger:     cfg.Logger,
 	}
@@ -33,7 +33,7 @@ func NewHubStateMonitor(cfg config.CollectorConfig) HubStateMonitor {
 type HubStateMonitor struct {
 	State      *types.HubStateResponse
 	HubAddress string
-	metrics    map[Metric]float64
+	metrics    map[MetricName]float64
 	apiClient  *client.TerraLiteForTerra
 	logger     *logrus.Logger
 }
@@ -81,7 +81,7 @@ func (h *HubStateMonitor) Handler(ctx context.Context) error {
 	return nil
 }
 
-func (h *HubStateMonitor) setStringMetric(m Metric, rawValue string) {
+func (h *HubStateMonitor) setStringMetric(m MetricName, rawValue string) {
 	v, err := strconv.ParseFloat(rawValue, 64)
 	if err != nil {
 		h.logger.Errorf("failed to set value \"%s\" to metric \"%s\": %+v\n", rawValue, m, err)
@@ -89,11 +89,11 @@ func (h *HubStateMonitor) setStringMetric(m Metric, rawValue string) {
 	h.metrics[m] = v
 }
 
-func (h HubStateMonitor) GetMetrics() map[Metric]float64 {
+func (h HubStateMonitor) GetMetrics() map[MetricName]float64 {
 	return h.metrics
 }
 
-func (h HubStateMonitor) GetMetricVectors() map[Metric]map[string]float64 {
+func (h HubStateMonitor) GetMetricVectors() map[MetricName]MetricVector {
 	return nil
 }
 

--- a/collector/monitors/hub_state_monitor.go
+++ b/collector/monitors/hub_state_monitor.go
@@ -93,6 +93,10 @@ func (h HubStateMonitor) GetMetrics() map[Metric]float64 {
 	return h.metrics
 }
 
+func (h HubStateMonitor) GetMetricVectors() map[Metric]map[string]float64 {
+	return nil
+}
+
 func (h *HubStateMonitor) SetApiClient(client *client.TerraLiteForTerra) {
 	h.apiClient = client
 }

--- a/collector/monitors/monitors.go
+++ b/collector/monitors/monitors.go
@@ -10,9 +10,11 @@ type Monitor interface {
 	// Handler fetches the data to inner storage
 	Handler(ctx context.Context) error
 	// GetMetrics - provides single value metrics fetched by Handler method
-	GetMetrics() map[Metric]float64
+	GetMetrics() map[MetricName]float64
 	// GetMetricVectors - provides set of a labeled values fetched by Handler method
-	GetMetricVectors() map[Metric]map[string]float64
+	GetMetricVectors() map[MetricName]MetricVector
 }
 
-type Metric string
+type MetricName string
+
+type MetricVector map[string]float64

--- a/collector/monitors/monitors.go
+++ b/collector/monitors/monitors.go
@@ -9,8 +9,10 @@ type Monitor interface {
 	InitMetrics()
 	// Handler fetches the data to inner storage
 	Handler(ctx context.Context) error
-	// GetMetrics - provides metrics fetched by Handler method
+	// GetMetrics - provides single value metrics fetched by Handler method
 	GetMetrics() map[Metric]float64
+	// GetMetricVectors - provides set of a labeled values fetched by Handler method
+	GetMetricVectors() map[Metric]map[string]float64
 }
 
 type Metric string

--- a/collector/monitors/reward_state_monitor.go
+++ b/collector/monitors/reward_state_monitor.go
@@ -90,6 +90,10 @@ func (h RewardStateMonitor) GetMetrics() map[Metric]float64 {
 	return h.metrics
 }
 
+func (h RewardStateMonitor) GetMetricVectors() map[Metric]map[string]float64 {
+	return nil
+}
+
 func (h *RewardStateMonitor) SetApiClient(client *client.TerraLiteForTerra) {
 	h.apiClient = client
 }

--- a/collector/monitors/reward_state_monitor.go
+++ b/collector/monitors/reward_state_monitor.go
@@ -14,14 +14,14 @@ import (
 )
 
 var (
-	GlobalIndex Metric = "global_index"
+	GlobalIndex MetricName = "global_index"
 )
 
 func NewRewardStateMonitor(cfg config.CollectorConfig) RewardStateMonitor {
 	m := RewardStateMonitor{
 		State:           &types.RewardStateResponse{},
 		ContractAddress: cfg.RewardContract,
-		metrics:         make(map[Metric]float64),
+		metrics:         make(map[MetricName]float64),
 		apiClient:       cfg.GetTerraClient(),
 		logger:          cfg.Logger,
 	}
@@ -32,7 +32,7 @@ func NewRewardStateMonitor(cfg config.CollectorConfig) RewardStateMonitor {
 type RewardStateMonitor struct {
 	State           *types.RewardStateResponse
 	ContractAddress string
-	metrics         map[Metric]float64
+	metrics         map[MetricName]float64
 	apiClient       *client.TerraLiteForTerra
 	logger          *logrus.Logger
 }
@@ -78,7 +78,7 @@ func (h *RewardStateMonitor) Handler(ctx context.Context) error {
 	return nil
 }
 
-func (h *RewardStateMonitor) setStringMetric(m Metric, rawValue string) {
+func (h *RewardStateMonitor) setStringMetric(m MetricName, rawValue string) {
 	v, err := strconv.ParseFloat(rawValue, 64)
 	if err != nil {
 		h.logger.Errorf("failed to set value \"%s\" to metric \"%s\": %+v\n", rawValue, m, err)
@@ -86,11 +86,11 @@ func (h *RewardStateMonitor) setStringMetric(m Metric, rawValue string) {
 	h.metrics[m] = v
 }
 
-func (h RewardStateMonitor) GetMetrics() map[Metric]float64 {
+func (h RewardStateMonitor) GetMetrics() map[MetricName]float64 {
 	return h.metrics
 }
 
-func (h RewardStateMonitor) GetMetricVectors() map[Metric]map[string]float64 {
+func (h RewardStateMonitor) GetMetricVectors() map[MetricName]MetricVector {
 	return nil
 }
 

--- a/collector/monitors/slashing_monitor.go
+++ b/collector/monitors/slashing_monitor.go
@@ -115,7 +115,7 @@ func (m *SlashingMonitor) Handler(ctx context.Context) error {
 				m.logger.Errorf("failed to Parse `missed_blocks_counter:`: %s", err)
 			} else {
 				if numMissedBlocks > 0 {
-					m.metricVectors[SlashingNumMissedBlocks][validatorPublicKey] += float64(numMissedBlocks)
+					m.metricVectors[SlashingNumMissedBlocks][m.validatorsRepository.DisplayName(validatorPublicKey)] += float64(numMissedBlocks)
 				}
 			}
 		}
@@ -169,6 +169,7 @@ func (m *SlashingMonitor) getValidatorsPublicKeys(ctx context.Context) ([]string
 
 type ValidatorsRepository interface {
 	GetValidatorsAddresses(ctx context.Context) ([]string, error)
+	DisplayName(string) string
 }
 
 type V1ValidatorsRepository struct {
@@ -211,4 +212,10 @@ func (r *V1ValidatorsRepository) GetValidatorsAddresses(ctx context.Context) ([]
 	}
 
 	return hubResp.Validators, nil
+}
+
+
+func (r *V1ValidatorsRepository) DisplayName(pubkey string) string {
+	// TODO: implement the real method to match pubkey with display name
+	return pubkey
 }

--- a/collector/monitors/slashing_monitor.go
+++ b/collector/monitors/slashing_monitor.go
@@ -18,9 +18,9 @@ import (
 )
 
 const (
-	SlashingNumJailedValidators     Metric = "slashing_num_jailed_validators"
-	SlashingNumTombstonedValidators Metric = "slashing_num_tombstoned_validators"
-	SlashingNumMissedBlocks         Metric = "slashing_num_missed_blocks" // TODO: add a "validator_address" label.
+	SlashingNumJailedValidators     MetricName = "slashing_num_jailed_validators"
+	SlashingNumTombstonedValidators MetricName = "slashing_num_tombstoned_validators"
+	SlashingNumMissedBlocks         MetricName = "slashing_num_missed_blocks" // TODO: add a "validator_address" label.
 )
 
 const (
@@ -28,8 +28,8 @@ const (
 )
 
 type SlashingMonitor struct {
-	metrics              map[Metric]float64
-	metricVectors        map[Metric]map[string]float64
+	metrics              map[MetricName]float64
+	metricVectors        map[MetricName]MetricVector
 	apiClient            *client.TerraLiteForTerra
 	validatorsRepository ValidatorsRepository
 	logger               *logrus.Logger
@@ -37,8 +37,8 @@ type SlashingMonitor struct {
 
 func NewSlashingMonitor(cfg config.CollectorConfig, repository ValidatorsRepository) *SlashingMonitor {
 	m := &SlashingMonitor{
-		metrics:              make(map[Metric]float64),
-		metricVectors:        make(map[Metric]map[string]float64),
+		metrics:              make(map[MetricName]float64),
+		metricVectors:        make(map[MetricName]MetricVector),
 		apiClient:            cfg.GetTerraClient(),
 		validatorsRepository: repository,
 		logger:               cfg.Logger,
@@ -52,13 +52,13 @@ func (m *SlashingMonitor) Name() string {
 }
 
 func (m *SlashingMonitor) InitMetrics() {
-	m.metrics = map[Metric]float64{
+	m.metrics = map[MetricName]float64{
 		SlashingNumJailedValidators:     0,
 		SlashingNumTombstonedValidators: 0,
 	}
 
-	m.metricVectors = map[Metric]map[string]float64{
-		SlashingNumMissedBlocks: make(map[string]float64),
+	m.metricVectors = map[MetricName]MetricVector{
+		SlashingNumMissedBlocks: make(MetricVector),
 	}
 }
 
@@ -128,11 +128,11 @@ func (m *SlashingMonitor) Handler(ctx context.Context) error {
 	return nil
 }
 
-func (m *SlashingMonitor) GetMetrics() map[Metric]float64 {
+func (m *SlashingMonitor) GetMetrics() map[MetricName]float64 {
 	return m.metrics
 }
 
-func (m SlashingMonitor) GetMetricVectors() map[Metric]map[string]float64 {
+func (m SlashingMonitor) GetMetricVectors() map[MetricName]MetricVector {
 	return m.metricVectors
 }
 

--- a/collector/monitors/slashing_monitor.go
+++ b/collector/monitors/slashing_monitor.go
@@ -217,5 +217,6 @@ func (r *V1ValidatorsRepository) GetValidatorsAddresses(ctx context.Context) ([]
 
 func (r *V1ValidatorsRepository) DisplayName(pubkey string) string {
 	// TODO: implement the real method to match pubkey with display name
-	return pubkey
+	valName := []rune(pubkey)
+	return string(valName[len(valName)-10:])
 }

--- a/collector/monitors/slashing_monitor.go
+++ b/collector/monitors/slashing_monitor.go
@@ -124,7 +124,7 @@ func (m *SlashingMonitor) Handler(ctx context.Context) error {
 			m.metrics[SlashingNumTombstonedValidators]++
 		}
 	}
-	m.logger.Infoln("updated",m.Name())
+	m.logger.Infoln("updated", m.Name())
 	return nil
 }
 

--- a/collector/monitors/slashing_monitor_test.go
+++ b/collector/monitors/slashing_monitor_test.go
@@ -29,6 +29,10 @@ func (r *MockV1ValidatorsRepository) GetValidatorsAddresses(ctx context.Context)
 	}, nil
 }
 
+func (r *MockV1ValidatorsRepository) DisplayName(pubkey string) string {
+	return pubkey
+}
+
 func (suite *SlashingMonitorTestSuite) TestSuccessfulRequestWithSlashing() {
 	validatorInfoData, err := ioutil.ReadFile("./test_data/slashing_validator_info.json")
 	suite.NoError(err)

--- a/collector/monitors/slashing_monitor_test.go
+++ b/collector/monitors/slashing_monitor_test.go
@@ -55,7 +55,7 @@ func (suite *SlashingMonitorTestSuite) TestSuccessfulRequestWithSlashing() {
 		expectedNumMissedBlocks         float64 = 5
 	)
 	var actualMissedBlocks float64
-	for _,missedBlocks := range metricVectors[SlashingNumMissedBlocks] {
+	for _, missedBlocks := range metricVectors[SlashingNumMissedBlocks] {
 		actualMissedBlocks += missedBlocks
 	}
 	suite.Equal(expectedNumTombstonedValidators, metrics[SlashingNumTombstonedValidators])
@@ -90,7 +90,7 @@ func (suite *SlashingMonitorTestSuite) TestSuccessfulRequestNoSlashing() {
 		expectedNumMissedBlocks         float64 = 0
 	)
 	var actualMissedBlocks float64
-	for _,missedBlocks := range metricVectors[SlashingNumMissedBlocks] {
+	for _, missedBlocks := range metricVectors[SlashingNumMissedBlocks] {
 		actualMissedBlocks += missedBlocks
 	}
 	suite.Equal(expectedNumTombstonedValidators, metrics[SlashingNumTombstonedValidators])

--- a/collector/monitors/slashing_monitor_test.go
+++ b/collector/monitors/slashing_monitor_test.go
@@ -29,10 +29,6 @@ func (r *MockV1ValidatorsRepository) GetValidatorsAddresses(ctx context.Context)
 	}, nil
 }
 
-func (r *MockV1ValidatorsRepository) DisplayName(pubkey string) string {
-	return pubkey
-}
-
 func (suite *SlashingMonitorTestSuite) TestSuccessfulRequestWithSlashing() {
 	validatorInfoData, err := ioutil.ReadFile("./test_data/slashing_validator_info.json")
 	suite.NoError(err)

--- a/collector/monitors/slashing_monitor_test.go
+++ b/collector/monitors/slashing_monitor_test.go
@@ -48,14 +48,19 @@ func (suite *SlashingMonitorTestSuite) TestSuccessfulRequestWithSlashing() {
 	suite.NoError(err)
 
 	metrics := m.GetMetrics()
+	metricVectors := m.GetMetricVectors()
 	var (
 		expectedNumTombstonedValidators float64 = 1
 		expectedNumJailedValidators     float64 = 1
 		expectedNumMissedBlocks         float64 = 5
 	)
+	var actualMissedBlocks float64
+	for _,missedBlocks := range metricVectors[SlashingNumMissedBlocks] {
+		actualMissedBlocks += missedBlocks
+	}
 	suite.Equal(expectedNumTombstonedValidators, metrics[SlashingNumTombstonedValidators])
 	suite.Equal(expectedNumJailedValidators, metrics[SlashingNumJailedValidators])
-	suite.Equal(expectedNumMissedBlocks, metrics[SlashingNumMissedBlocks])
+	suite.Equal(expectedNumMissedBlocks, actualMissedBlocks)
 }
 
 func (suite *SlashingMonitorTestSuite) TestSuccessfulRequestNoSlashing() {
@@ -77,14 +82,20 @@ func (suite *SlashingMonitorTestSuite) TestSuccessfulRequestNoSlashing() {
 	suite.NoError(err)
 
 	metrics := m.GetMetrics()
+	metricVectors := m.GetMetricVectors()
+
 	var (
 		expectedNumTombstonedValidators float64 = 0
 		expectedNumJailedValidators     float64 = 0
 		expectedNumMissedBlocks         float64 = 0
 	)
+	var actualMissedBlocks float64
+	for _,missedBlocks := range metricVectors[SlashingNumMissedBlocks] {
+		actualMissedBlocks += missedBlocks
+	}
 	suite.Equal(expectedNumTombstonedValidators, metrics[SlashingNumTombstonedValidators])
 	suite.Equal(expectedNumJailedValidators, metrics[SlashingNumJailedValidators])
-	suite.Equal(expectedNumMissedBlocks, metrics[SlashingNumMissedBlocks])
+	suite.Equal(expectedNumMissedBlocks, actualMissedBlocks)
 }
 
 func (suite *UpdateGlobalIndexMonitorTestSuite) TestFailedSlashingRequest() {

--- a/collector/monitors/test_data/slashing_validator_info.json
+++ b/collector/monitors/test_data/slashing_validator_info.json
@@ -1,6 +1,9 @@
 {
   "height": "1",
   "result": {
-    "consensus_pubkey": "terravalconspub1zcjduepqw2hyr7u7y70z5kdewn00xuq0wwcvnn0s7x5pjqcdpn80qsyctcpqcjhz4c"
+    "consensus_pubkey": "terravalconspub1zcjduepqw2hyr7u7y70z5kdewn00xuq0wwcvnn0s7x5pjqcdpn80qsyctcpqcjhz4c",
+    "description": {
+      "moniker": "Test validator"
+    }
   }
 }

--- a/collector/monitors/update_global_index_monitor.go
+++ b/collector/monitors/update_global_index_monitor.go
@@ -148,6 +148,10 @@ func (m UpdateGlobalIndexMonitor) GetMetrics() map[Metric]float64 {
 	return m.metrics
 }
 
+func (m UpdateGlobalIndexMonitor) GetMetricVectors() map[Metric]map[string]float64 {
+	return nil
+}
+
 func getTxRawLog(tx *models.GetTxListResultTxs) string {
 	if tx == nil || tx.RawLog == nil {
 		return ""

--- a/collector/monitors/update_global_index_monitor.go
+++ b/collector/monitors/update_global_index_monitor.go
@@ -23,11 +23,11 @@ const (
 const UpdateGlobalIndexBase64Encoded = "eyJ1cGRhdGVfZ2xvYmFsX2luZGV4Ijp7fX0="
 
 const (
-	UpdateGlobalIndexSuccessfulTxSinceLastCheck Metric = "update_global_index_successful_tx_since_last_check"
-	UpdateGlobalIndexFailedTxSinceLastCheck     Metric = "update_global_index_failed_tx_since_last_check"
-	UpdateGlobalIndexGasWanted                  Metric = "update_global_index_gas_wanted"
-	UpdateGlobalIndexGasUsed                    Metric = "update_global_index_gas_used"
-	UpdateGlobalIndexUUSDFee                    Metric = "update_global_index_uusd_fee"
+	UpdateGlobalIndexSuccessfulTxSinceLastCheck MetricName = "update_global_index_successful_tx_since_last_check"
+	UpdateGlobalIndexFailedTxSinceLastCheck     MetricName = "update_global_index_failed_tx_since_last_check"
+	UpdateGlobalIndexGasWanted                  MetricName = "update_global_index_gas_wanted"
+	UpdateGlobalIndexGasUsed                    MetricName = "update_global_index_gas_used"
+	UpdateGlobalIndexUUSDFee                    MetricName = "update_global_index_uusd_fee"
 )
 
 const threshold int = 10
@@ -36,7 +36,7 @@ const UUSDDenom = "uusd"
 
 type UpdateGlobalIndexMonitor struct {
 	ContractAddress  string
-	metrics          map[Metric]float64
+	metrics          map[MetricName]float64
 	apiClient        *client.TerraLiteForTerra
 	logger           *logrus.Logger
 	lastMaxCheckedID int
@@ -45,7 +45,7 @@ type UpdateGlobalIndexMonitor struct {
 func NewUpdateGlobalIndexMonitor(cfg config.CollectorConfig) UpdateGlobalIndexMonitor {
 	m := UpdateGlobalIndexMonitor{
 		ContractAddress: cfg.UpdateGlobalIndexBotAddress,
-		metrics:         make(map[Metric]float64),
+		metrics:         make(map[MetricName]float64),
 		apiClient:       cfg.GetTerraClient(),
 		logger:          cfg.Logger,
 	}
@@ -144,11 +144,11 @@ func (m *UpdateGlobalIndexMonitor) processTransactions(
 	return newMaxCheckedID, alreadyProcessedFound
 }
 
-func (m UpdateGlobalIndexMonitor) GetMetrics() map[Metric]float64 {
+func (m UpdateGlobalIndexMonitor) GetMetrics() map[MetricName]float64 {
 	return m.metrics
 }
 
-func (m UpdateGlobalIndexMonitor) GetMetricVectors() map[Metric]map[string]float64 {
+func (m UpdateGlobalIndexMonitor) GetMetricVectors() map[MetricName]MetricVector {
 	return nil
 }
 

--- a/collector/monitors/whitelisted_validators_monitor.go
+++ b/collector/monitors/whitelisted_validators_monitor.go
@@ -11,22 +11,22 @@ import (
 )
 
 const (
-	WhitelistedValidatorsCRC32 = "whitelisted_validators_crc32"
-	WhitelistedValidatorsNum   = "whitelisted_validators_num"
+	WhitelistedValidatorsCRC32 MetricName = "whitelisted_validators_crc32"
+	WhitelistedValidatorsNum   MetricName = "whitelisted_validators_num"
 )
 
 type WhitelistedValidatorsMonitor struct {
-	metrics   map[Metric]float64
-	apiClient *client.TerraLiteForTerra
-	logger    *logrus.Logger
+	metrics              map[MetricName]float64
+	apiClient            *client.TerraLiteForTerra
+	logger               *logrus.Logger
 	validatorsRepository ValidatorsRepository
 }
 
 func NewWhitelistedValidatorsMonitor(cfg config.CollectorConfig, repository ValidatorsRepository) WhitelistedValidatorsMonitor {
 	m := WhitelistedValidatorsMonitor{
-		metrics:   make(map[Metric]float64),
-		apiClient: cfg.GetTerraClient(),
-		logger:    cfg.Logger,
+		metrics:              make(map[MetricName]float64),
+		apiClient:            cfg.GetTerraClient(),
+		logger:               cfg.Logger,
 		validatorsRepository: repository,
 	}
 
@@ -42,19 +42,22 @@ func (m *WhitelistedValidatorsMonitor) InitMetrics() {
 	m.metrics[WhitelistedValidatorsNum] = 0
 }
 
-func (m WhitelistedValidatorsMonitor) GetMetrics() map[Metric]float64 {
+func (m WhitelistedValidatorsMonitor) GetMetrics() map[MetricName]float64 {
 	return m.metrics
+}
+
+func (m WhitelistedValidatorsMonitor) GetMetricVectors() map[MetricName]MetricVector {
+	return nil
 }
 
 func (m *WhitelistedValidatorsMonitor) Handler(ctx context.Context) error {
 
-	validators,err := m.validatorsRepository.GetValidatorsAddresses(ctx)
+	validators, err := m.validatorsRepository.GetValidatorsAddresses(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get whiltelisted validators for %s: %w",m.Name(), err)
+		return fmt.Errorf("failed to get whiltelisted validators for %s: %w", m.Name(), err)
 	}
 
-
-	m.metrics[WhitelistedValidatorsCRC32] = float64(crc32.ChecksumIEEE([]byte(strings.Join(validators,""))))
+	m.metrics[WhitelistedValidatorsCRC32] = float64(crc32.ChecksumIEEE([]byte(strings.Join(validators, ""))))
 	m.metrics[WhitelistedValidatorsNum] = float64(len(validators))
 	m.logger.Infoln("updated ", m.Name())
 	return nil

--- a/collector/types/types.go
+++ b/collector/types/types.go
@@ -139,7 +139,7 @@ type ValidatorsRegistryConfig struct {
 }
 
 type AirDropRegistryConfig struct {
-	Owner       string `json:"owner"`
-	HubContract string `json:"hub_contract"`
+	Owner        string   `json:"owner"`
+	HubContract  string   `json:"hub_contract"`
 	AirDropToken []string `json:"airdrop_tokens"`
 }

--- a/docker/config/grafana/provisioning/dashboards/lido_basset/lido_basset.json
+++ b/docker/config/grafana/provisioning/dashboards/lido_basset/lido_basset.json
@@ -1131,7 +1131,7 @@
           "expr": "slashing_num_missed_blocks{}",
           "hide": false,
           "interval": "",
-          "legendFormat": "number of missed blocks (all validators)",
+          "legendFormat": "number of missed blocks ({{label}})",
           "refId": "C"
         }
       ],

--- a/docker/config/grafana/provisioning/dashboards/lido_basset/lido_basset.json
+++ b/docker/config/grafana/provisioning/dashboards/lido_basset/lido_basset.json
@@ -1131,7 +1131,7 @@
           "expr": "slashing_num_missed_blocks{}",
           "hide": false,
           "interval": "",
-          "legendFormat": "number of missed blocks ({{label}})",
+          "legendFormat": "{{label}}",
           "refId": "C"
         }
       ],

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -81,7 +81,7 @@ func (p *PromExtractor) updateGaugeVectorValue(name monitors.MetricName) error {
 
 func (p PromExtractor) UpdateMetrics(ctx context.Context) {
 	errors := p.collector.UpdateData(ctx)
-	for _,err := range errors {
+	for _, err := range errors {
 		p.log.Errorf("failed to update collector data: %v", err)
 	}
 

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -13,10 +13,10 @@ import (
 func NewPromExtractor(c collector.Collector, logger *logrus.Logger) PromExtractor {
 	p := PromExtractor{}
 	p.collector = c
-	p.Gauges = make(map[monitors.Metric]prometheus.Gauge)
-	p.GaugeVectors = make(map[monitors.Metric]*prometheus.GaugeVec)
-	p.GaugeMetrics = []monitors.Metric{}
-	p.GaugeMetricVectors = []monitors.Metric{}
+	p.Gauges = make(map[monitors.MetricName]prometheus.Gauge)
+	p.GaugeVectors = make(map[monitors.MetricName]*prometheus.GaugeVec)
+	p.GaugeMetrics = []monitors.MetricName{}
+	p.GaugeMetricVectors = []monitors.MetricName{}
 	p.log = logger
 	for _, m := range p.collector.ProvidedMetrics() {
 		p.addGauge(m)
@@ -29,14 +29,14 @@ func NewPromExtractor(c collector.Collector, logger *logrus.Logger) PromExtracto
 
 type PromExtractor struct {
 	collector          collector.Collector
-	Gauges             map[monitors.Metric]prometheus.Gauge
-	GaugeVectors       map[monitors.Metric]*prometheus.GaugeVec
-	GaugeMetrics       []monitors.Metric
-	GaugeMetricVectors []monitors.Metric
+	Gauges             map[monitors.MetricName]prometheus.Gauge
+	GaugeVectors       map[monitors.MetricName]*prometheus.GaugeVec
+	GaugeMetrics       []monitors.MetricName
+	GaugeMetricVectors []monitors.MetricName
 	log                *logrus.Logger
 }
 
-func (p *PromExtractor) addGauge(name monitors.Metric) {
+func (p *PromExtractor) addGauge(name monitors.MetricName) {
 	p.Gauges[name] = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: string(name),
@@ -46,7 +46,7 @@ func (p *PromExtractor) addGauge(name monitors.Metric) {
 	p.GaugeMetrics = append(p.GaugeMetrics, name)
 }
 
-func (p *PromExtractor) addGaugeVector(name monitors.Metric) {
+func (p *PromExtractor) addGaugeVector(name monitors.MetricName) {
 	p.GaugeVectors[name] = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: string(name),
@@ -58,7 +58,7 @@ func (p *PromExtractor) addGaugeVector(name monitors.Metric) {
 	p.GaugeMetricVectors = append(p.GaugeMetricVectors, name)
 }
 
-func (p *PromExtractor) updateGaugeValue(name monitors.Metric) error {
+func (p *PromExtractor) updateGaugeValue(name monitors.MetricName) error {
 	value, err := p.collector.Get(name)
 	if err != nil {
 		return fmt.Errorf("failed to update metric \"%s\": %w", name, err)
@@ -68,7 +68,7 @@ func (p *PromExtractor) updateGaugeValue(name monitors.Metric) error {
 	return nil
 }
 
-func (p *PromExtractor) updateGaugeVectorValue(name monitors.Metric) error {
+func (p *PromExtractor) updateGaugeVectorValue(name monitors.MetricName) error {
 	vector, err := p.collector.GetVector(name)
 	if err != nil {
 		return fmt.Errorf("failed to update metric \"%s\": %w", name, err)

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -92,7 +92,7 @@ func (p PromExtractor) UpdateMetrics(ctx context.Context) {
 		}
 	}
 	for _, gaugeName := range p.GaugeMetricVectors {
-		err = p.updateGaugeVectorValue(gaugeName)
+		err := p.updateGaugeVectorValue(gaugeName)
 		if err != nil {
 			p.log.Errorf("failed to update gauge value \"%s\": %v", gaugeName, err)
 		}

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -14,19 +14,26 @@ func NewPromExtractor(c collector.Collector, logger *logrus.Logger) PromExtracto
 	p := PromExtractor{}
 	p.collector = c
 	p.Gauges = make(map[monitors.Metric]prometheus.Gauge)
+	p.GaugeVectors = make(map[monitors.Metric]*prometheus.GaugeVec)
 	p.GaugeMetrics = []monitors.Metric{}
+	p.GaugeMetricVectors = []monitors.Metric{}
 	p.log = logger
 	for _, m := range p.collector.ProvidedMetrics() {
 		p.addGauge(m)
+	}
+	for _, m := range p.collector.ProvidedMetricVectors() {
+		p.addGaugeVector(m)
 	}
 	return p
 }
 
 type PromExtractor struct {
-	collector    collector.Collector
-	Gauges       map[monitors.Metric]prometheus.Gauge
-	GaugeMetrics []monitors.Metric
-	log          *logrus.Logger
+	collector          collector.Collector
+	Gauges             map[monitors.Metric]prometheus.Gauge
+	GaugeVectors       map[monitors.Metric]*prometheus.GaugeVec
+	GaugeMetrics       []monitors.Metric
+	GaugeMetricVectors []monitors.Metric
+	log                *logrus.Logger
 }
 
 func (p *PromExtractor) addGauge(name monitors.Metric) {
@@ -39,6 +46,18 @@ func (p *PromExtractor) addGauge(name monitors.Metric) {
 	p.GaugeMetrics = append(p.GaugeMetrics, name)
 }
 
+func (p *PromExtractor) addGaugeVector(name monitors.Metric) {
+	p.GaugeVectors[name] = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: string(name),
+		},
+		[]string{"label"},
+	)
+
+	prometheus.MustRegister(p.GaugeVectors[name])
+	p.GaugeMetricVectors = append(p.GaugeMetricVectors, name)
+}
+
 func (p *PromExtractor) updateGaugeValue(name monitors.Metric) error {
 	value, err := p.collector.Get(name)
 	if err != nil {
@@ -46,6 +65,17 @@ func (p *PromExtractor) updateGaugeValue(name monitors.Metric) error {
 	}
 
 	p.Gauges[name].Set(value)
+	return nil
+}
+
+func (p *PromExtractor) updateGaugeVectorValue(name monitors.Metric) error {
+	vector, err := p.collector.GetVector(name)
+	if err != nil {
+		return fmt.Errorf("failed to update metric \"%s\": %w", name, err)
+	}
+	for label := range vector {
+		p.GaugeVectors[name].With(prometheus.Labels{"label": label}).Set(vector[label])
+	}
 	return nil
 }
 
@@ -57,6 +87,12 @@ func (p PromExtractor) UpdateMetrics(ctx context.Context) {
 
 	for _, gaugeName := range p.GaugeMetrics {
 		err := p.updateGaugeValue(gaugeName)
+		if err != nil {
+			p.log.Errorf("failed to update gauge value \"%s\": %v", gaugeName, err)
+		}
+	}
+	for _, gaugeName := range p.GaugeMetricVectors {
+		err = p.updateGaugeVectorValue(gaugeName)
 		if err != nil {
 			p.log.Errorf("failed to update gauge value \"%s\": %v", gaugeName, err)
 		}

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func createCollector() collector.LCDCollector {
 	configCRC32Monitor := monitors.NewConfigsCRC32Monitor(defConfig)
 	c.RegisterMonitor(&configCRC32Monitor)
 
-	whitelistedValidatorsMonitor := monitors.NewWhitelistedValidatorsMonitor(defConfig,validatorsRepository)
+	whitelistedValidatorsMonitor := monitors.NewWhitelistedValidatorsMonitor(defConfig, validatorsRepository)
 	c.RegisterMonitor(&whitelistedValidatorsMonitor)
 
 	return c

--- a/openapi/client/terra_lite_for_terra_client.go
+++ b/openapi/client/terra_lite_for_terra_client.go
@@ -8,8 +8,7 @@ package client
 import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
-
-	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/strfmt"
 
 	"github.com/lidofinance/terra-monitors/openapi/client/transactions"
 	"github.com/lidofinance/terra-monitors/openapi/client/wasm"
@@ -57,11 +56,8 @@ func New(transport runtime.ClientTransport, formats strfmt.Registry) *TerraLiteF
 
 	cli := new(TerraLiteForTerra)
 	cli.Transport = transport
-
 	cli.Transactions = transactions.New(transport, formats)
-
 	cli.Wasm = wasm.New(transport, formats)
-
 	return cli
 }
 
@@ -106,9 +102,9 @@ func (cfg *TransportConfig) WithSchemes(schemes []string) *TransportConfig {
 
 // TerraLiteForTerra is a client for terra lite for terra
 type TerraLiteForTerra struct {
-	Transactions *transactions.Client
+	Transactions transactions.ClientService
 
-	Wasm *wasm.Client
+	Wasm wasm.ClientService
 
 	Transport runtime.ClientTransport
 }
@@ -116,9 +112,6 @@ type TerraLiteForTerra struct {
 // SetTransport changes the transport on the client and all its subresources
 func (c *TerraLiteForTerra) SetTransport(transport runtime.ClientTransport) {
 	c.Transport = transport
-
 	c.Transactions.SetTransport(transport)
-
 	c.Wasm.SetTransport(transport)
-
 }

--- a/openapi/client/transactions/get_slashing_validators_validator_pub_key_signing_info_parameters.go
+++ b/openapi/client/transactions/get_slashing_validators_validator_pub_key_signing_info_parameters.go
@@ -13,63 +13,76 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
-
-	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/strfmt"
 )
 
-// NewGetSlashingValidatorsValidatorPubKeySigningInfoParams creates a new GetSlashingValidatorsValidatorPubKeySigningInfoParams object
-// with the default values initialized.
+// NewGetSlashingValidatorsValidatorPubKeySigningInfoParams creates a new GetSlashingValidatorsValidatorPubKeySigningInfoParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetSlashingValidatorsValidatorPubKeySigningInfoParams() *GetSlashingValidatorsValidatorPubKeySigningInfoParams {
-	var ()
 	return &GetSlashingValidatorsValidatorPubKeySigningInfoParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetSlashingValidatorsValidatorPubKeySigningInfoParamsWithTimeout creates a new GetSlashingValidatorsValidatorPubKeySigningInfoParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetSlashingValidatorsValidatorPubKeySigningInfoParamsWithTimeout(timeout time.Duration) *GetSlashingValidatorsValidatorPubKeySigningInfoParams {
-	var ()
 	return &GetSlashingValidatorsValidatorPubKeySigningInfoParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetSlashingValidatorsValidatorPubKeySigningInfoParamsWithContext creates a new GetSlashingValidatorsValidatorPubKeySigningInfoParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetSlashingValidatorsValidatorPubKeySigningInfoParamsWithContext(ctx context.Context) *GetSlashingValidatorsValidatorPubKeySigningInfoParams {
-	var ()
 	return &GetSlashingValidatorsValidatorPubKeySigningInfoParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetSlashingValidatorsValidatorPubKeySigningInfoParamsWithHTTPClient creates a new GetSlashingValidatorsValidatorPubKeySigningInfoParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetSlashingValidatorsValidatorPubKeySigningInfoParamsWithHTTPClient(client *http.Client) *GetSlashingValidatorsValidatorPubKeySigningInfoParams {
-	var ()
 	return &GetSlashingValidatorsValidatorPubKeySigningInfoParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetSlashingValidatorsValidatorPubKeySigningInfoParams contains all the parameters to send to the API endpoint
-for the get slashing validators validator pub key signing info operation typically these are written to a http.Request
+/* GetSlashingValidatorsValidatorPubKeySigningInfoParams contains all the parameters to send to the API endpoint
+   for the get slashing validators validator pub key signing info operation.
+
+   Typically these are written to a http.Request.
 */
 type GetSlashingValidatorsValidatorPubKeySigningInfoParams struct {
 
-	/*ValidatorPubKey
-	  validator public key
+	/* ValidatorPubKey.
 
+	   validator public key
 	*/
 	ValidatorPubKey string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get slashing validators validator pub key signing info params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetSlashingValidatorsValidatorPubKeySigningInfoParams) WithDefaults() *GetSlashingValidatorsValidatorPubKeySigningInfoParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get slashing validators validator pub key signing info params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetSlashingValidatorsValidatorPubKeySigningInfoParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get slashing validators validator pub key signing info params

--- a/openapi/client/transactions/get_slashing_validators_validator_pub_key_signing_info_responses.go
+++ b/openapi/client/transactions/get_slashing_validators_validator_pub_key_signing_info_responses.go
@@ -6,16 +6,16 @@ package transactions
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"fmt"
 	"io"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
-	strfmt "github.com/go-openapi/strfmt"
-
-	models "github.com/lidofinance/terra-monitors/openapi/models"
+	"github.com/lidofinance/terra-monitors/openapi/models"
 )
 
 // GetSlashingValidatorsValidatorPubKeySigningInfoReader is a Reader for the GetSlashingValidatorsValidatorPubKeySigningInfo structure.
@@ -38,9 +38,8 @@ func (o *GetSlashingValidatorsValidatorPubKeySigningInfoReader) ReadResponse(res
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -49,7 +48,7 @@ func NewGetSlashingValidatorsValidatorPubKeySigningInfoOK() *GetSlashingValidato
 	return &GetSlashingValidatorsValidatorPubKeySigningInfoOK{}
 }
 
-/*GetSlashingValidatorsValidatorPubKeySigningInfoOK handles this case with default header values.
+/* GetSlashingValidatorsValidatorPubKeySigningInfoOK describes a response with status code 200, with default header values.
 
 Success
 */
@@ -60,7 +59,6 @@ type GetSlashingValidatorsValidatorPubKeySigningInfoOK struct {
 func (o *GetSlashingValidatorsValidatorPubKeySigningInfoOK) Error() string {
 	return fmt.Sprintf("[GET /slashing/validators/{validatorPubKey}/signing_info][%d] getSlashingValidatorsValidatorPubKeySigningInfoOK  %+v", 200, o.Payload)
 }
-
 func (o *GetSlashingValidatorsValidatorPubKeySigningInfoOK) GetPayload() *GetSlashingValidatorsValidatorPubKeySigningInfoOKBody {
 	return o.Payload
 }
@@ -82,7 +80,7 @@ func NewGetSlashingValidatorsValidatorPubKeySigningInfoBadRequest() *GetSlashing
 	return &GetSlashingValidatorsValidatorPubKeySigningInfoBadRequest{}
 }
 
-/*GetSlashingValidatorsValidatorPubKeySigningInfoBadRequest handles this case with default header values.
+/* GetSlashingValidatorsValidatorPubKeySigningInfoBadRequest describes a response with status code 400, with default header values.
 
 Error
 */
@@ -93,7 +91,6 @@ type GetSlashingValidatorsValidatorPubKeySigningInfoBadRequest struct {
 func (o *GetSlashingValidatorsValidatorPubKeySigningInfoBadRequest) Error() string {
 	return fmt.Sprintf("[GET /slashing/validators/{validatorPubKey}/signing_info][%d] getSlashingValidatorsValidatorPubKeySigningInfoBadRequest  %+v", 400, o.Payload)
 }
-
 func (o *GetSlashingValidatorsValidatorPubKeySigningInfoBadRequest) GetPayload() *GetSlashingValidatorsValidatorPubKeySigningInfoBadRequestBody {
 	return o.Payload
 }
@@ -127,6 +124,11 @@ type GetSlashingValidatorsValidatorPubKeySigningInfoBadRequestBody struct {
 
 // Validate validates this get slashing validators validator pub key signing info bad request body
 func (o *GetSlashingValidatorsValidatorPubKeySigningInfoBadRequestBody) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this get slashing validators validator pub key signing info bad request body based on context it is used
+func (o *GetSlashingValidatorsValidatorPubKeySigningInfoBadRequestBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 
@@ -175,13 +177,40 @@ func (o *GetSlashingValidatorsValidatorPubKeySigningInfoOKBody) Validate(formats
 }
 
 func (o *GetSlashingValidatorsValidatorPubKeySigningInfoOKBody) validateResult(formats strfmt.Registry) error {
-
 	if swag.IsZero(o.Result) { // not required
 		return nil
 	}
 
 	if o.Result != nil {
 		if err := o.Result.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("getSlashingValidatorsValidatorPubKeySigningInfoOK" + "." + "result")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get slashing validators validator pub key signing info o k body based on the context it is used
+func (o *GetSlashingValidatorsValidatorPubKeySigningInfoOKBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.contextValidateResult(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetSlashingValidatorsValidatorPubKeySigningInfoOKBody) contextValidateResult(ctx context.Context, formats strfmt.Registry) error {
+
+	if o.Result != nil {
+		if err := o.Result.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("getSlashingValidatorsValidatorPubKeySigningInfoOK" + "." + "result")
 			}

--- a/openapi/client/transactions/get_staking_validators_validator_addr_parameters.go
+++ b/openapi/client/transactions/get_staking_validators_validator_addr_parameters.go
@@ -13,63 +13,76 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
-
-	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/strfmt"
 )
 
-// NewGetStakingValidatorsValidatorAddrParams creates a new GetStakingValidatorsValidatorAddrParams object
-// with the default values initialized.
+// NewGetStakingValidatorsValidatorAddrParams creates a new GetStakingValidatorsValidatorAddrParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetStakingValidatorsValidatorAddrParams() *GetStakingValidatorsValidatorAddrParams {
-	var ()
 	return &GetStakingValidatorsValidatorAddrParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetStakingValidatorsValidatorAddrParamsWithTimeout creates a new GetStakingValidatorsValidatorAddrParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetStakingValidatorsValidatorAddrParamsWithTimeout(timeout time.Duration) *GetStakingValidatorsValidatorAddrParams {
-	var ()
 	return &GetStakingValidatorsValidatorAddrParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetStakingValidatorsValidatorAddrParamsWithContext creates a new GetStakingValidatorsValidatorAddrParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetStakingValidatorsValidatorAddrParamsWithContext(ctx context.Context) *GetStakingValidatorsValidatorAddrParams {
-	var ()
 	return &GetStakingValidatorsValidatorAddrParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetStakingValidatorsValidatorAddrParamsWithHTTPClient creates a new GetStakingValidatorsValidatorAddrParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetStakingValidatorsValidatorAddrParamsWithHTTPClient(client *http.Client) *GetStakingValidatorsValidatorAddrParams {
-	var ()
 	return &GetStakingValidatorsValidatorAddrParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetStakingValidatorsValidatorAddrParams contains all the parameters to send to the API endpoint
-for the get staking validators validator addr operation typically these are written to a http.Request
+/* GetStakingValidatorsValidatorAddrParams contains all the parameters to send to the API endpoint
+   for the get staking validators validator addr operation.
+
+   Typically these are written to a http.Request.
 */
 type GetStakingValidatorsValidatorAddrParams struct {
 
-	/*ValidatorAddr
-	  validator address
+	/* ValidatorAddr.
 
+	   validator address
 	*/
 	ValidatorAddr string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get staking validators validator addr params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetStakingValidatorsValidatorAddrParams) WithDefaults() *GetStakingValidatorsValidatorAddrParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get staking validators validator addr params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetStakingValidatorsValidatorAddrParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get staking validators validator addr params

--- a/openapi/client/transactions/get_staking_validators_validator_addr_responses.go
+++ b/openapi/client/transactions/get_staking_validators_validator_addr_responses.go
@@ -6,16 +6,16 @@ package transactions
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"fmt"
 	"io"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
-	strfmt "github.com/go-openapi/strfmt"
-
-	models "github.com/lidofinance/terra-monitors/openapi/models"
+	"github.com/lidofinance/terra-monitors/openapi/models"
 )
 
 // GetStakingValidatorsValidatorAddrReader is a Reader for the GetStakingValidatorsValidatorAddr structure.
@@ -38,9 +38,8 @@ func (o *GetStakingValidatorsValidatorAddrReader) ReadResponse(response runtime.
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -49,7 +48,7 @@ func NewGetStakingValidatorsValidatorAddrOK() *GetStakingValidatorsValidatorAddr
 	return &GetStakingValidatorsValidatorAddrOK{}
 }
 
-/*GetStakingValidatorsValidatorAddrOK handles this case with default header values.
+/* GetStakingValidatorsValidatorAddrOK describes a response with status code 200, with default header values.
 
 Success
 */
@@ -60,7 +59,6 @@ type GetStakingValidatorsValidatorAddrOK struct {
 func (o *GetStakingValidatorsValidatorAddrOK) Error() string {
 	return fmt.Sprintf("[GET /staking/validators/{validatorAddr}][%d] getStakingValidatorsValidatorAddrOK  %+v", 200, o.Payload)
 }
-
 func (o *GetStakingValidatorsValidatorAddrOK) GetPayload() *GetStakingValidatorsValidatorAddrOKBody {
 	return o.Payload
 }
@@ -82,7 +80,7 @@ func NewGetStakingValidatorsValidatorAddrBadRequest() *GetStakingValidatorsValid
 	return &GetStakingValidatorsValidatorAddrBadRequest{}
 }
 
-/*GetStakingValidatorsValidatorAddrBadRequest handles this case with default header values.
+/* GetStakingValidatorsValidatorAddrBadRequest describes a response with status code 400, with default header values.
 
 Error
 */
@@ -93,7 +91,6 @@ type GetStakingValidatorsValidatorAddrBadRequest struct {
 func (o *GetStakingValidatorsValidatorAddrBadRequest) Error() string {
 	return fmt.Sprintf("[GET /staking/validators/{validatorAddr}][%d] getStakingValidatorsValidatorAddrBadRequest  %+v", 400, o.Payload)
 }
-
 func (o *GetStakingValidatorsValidatorAddrBadRequest) GetPayload() *GetStakingValidatorsValidatorAddrBadRequestBody {
 	return o.Payload
 }
@@ -127,6 +124,11 @@ type GetStakingValidatorsValidatorAddrBadRequestBody struct {
 
 // Validate validates this get staking validators validator addr bad request body
 func (o *GetStakingValidatorsValidatorAddrBadRequestBody) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this get staking validators validator addr bad request body based on context it is used
+func (o *GetStakingValidatorsValidatorAddrBadRequestBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 
@@ -175,13 +177,40 @@ func (o *GetStakingValidatorsValidatorAddrOKBody) Validate(formats strfmt.Regist
 }
 
 func (o *GetStakingValidatorsValidatorAddrOKBody) validateResult(formats strfmt.Registry) error {
-
 	if swag.IsZero(o.Result) { // not required
 		return nil
 	}
 
 	if o.Result != nil {
 		if err := o.Result.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("getStakingValidatorsValidatorAddrOK" + "." + "result")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get staking validators validator addr o k body based on the context it is used
+func (o *GetStakingValidatorsValidatorAddrOKBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.contextValidateResult(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetStakingValidatorsValidatorAddrOKBody) contextValidateResult(ctx context.Context, formats strfmt.Registry) error {
+
+	if o.Result != nil {
+		if err := o.Result.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("getStakingValidatorsValidatorAddrOK" + "." + "result")
 			}

--- a/openapi/client/transactions/get_v1_txs_parameters.go
+++ b/openapi/client/transactions/get_v1_txs_parameters.go
@@ -13,114 +13,137 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-
-	strfmt "github.com/go-openapi/strfmt"
 )
 
-// NewGetV1TxsParams creates a new GetV1TxsParams object
-// with the default values initialized.
+// NewGetV1TxsParams creates a new GetV1TxsParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetV1TxsParams() *GetV1TxsParams {
-	var ()
 	return &GetV1TxsParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetV1TxsParamsWithTimeout creates a new GetV1TxsParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetV1TxsParamsWithTimeout(timeout time.Duration) *GetV1TxsParams {
-	var ()
 	return &GetV1TxsParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetV1TxsParamsWithContext creates a new GetV1TxsParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetV1TxsParamsWithContext(ctx context.Context) *GetV1TxsParams {
-	var ()
 	return &GetV1TxsParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetV1TxsParamsWithHTTPClient creates a new GetV1TxsParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetV1TxsParamsWithHTTPClient(client *http.Client) *GetV1TxsParams {
-	var ()
 	return &GetV1TxsParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetV1TxsParams contains all the parameters to send to the API endpoint
-for the get v1 txs operation typically these are written to a http.Request
+/* GetV1TxsParams contains all the parameters to send to the API endpoint
+   for the get v1 txs operation.
+
+   Typically these are written to a http.Request.
 */
 type GetV1TxsParams struct {
 
-	/*Account
-	  Account address
+	/* Account.
 
+	   Account address
 	*/
 	Account *string
-	/*Action
-	  Type of tx (account is required)
 
+	/* Action.
+
+	   Type of tx (account is required)
 	*/
 	Action *string
-	/*Block
-	  Block number
 
+	/* Block.
+
+	   Block number
 	*/
 	Block *string
-	/*ChainID
-	  Chain ID of Blockchain (default: chain id of mainnet)
 
+	/* ChainID.
+
+	   Chain ID of Blockchain (default: chain id of mainnet)
 	*/
 	ChainID *string
-	/*From
-	  Timestamp from
 
+	/* From.
+
+	   Timestamp from
 	*/
 	From *float64
-	/*Limit
-	  Size of page
 
+	/* Limit.
+
+	   Size of page
 	*/
 	Limit *float64
-	/*Memo
-	  Memo filter
 
+	/* Memo.
+
+	   Memo filter
 	*/
 	Memo *string
-	/*Offset
-	  Use last id from previous result for pagination
 
+	/* Offset.
+
+	   Use last id from previous result for pagination
 	*/
 	Offset *float64
-	/*Order
-	  ,'DESC'] Ordering (default: DESC)
 
+	/* Order.
+
+	   ,'DESC'] Ordering (default: DESC)
 	*/
 	Order *string
-	/*Page
-	  # of page
 
+	/* Page.
+
+	   # of page
 	*/
 	Page *float64
-	/*To
-	  Timestamp to
 
+	/* To.
+
+	   Timestamp to
 	*/
 	To *float64
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get v1 txs params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetV1TxsParams) WithDefaults() *GetV1TxsParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get v1 txs params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetV1TxsParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get v1 txs params
@@ -289,176 +312,187 @@ func (o *GetV1TxsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Regi
 
 		// query param account
 		var qrAccount string
+
 		if o.Account != nil {
 			qrAccount = *o.Account
 		}
 		qAccount := qrAccount
 		if qAccount != "" {
+
 			if err := r.SetQueryParam("account", qAccount); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if o.Action != nil {
 
 		// query param action
 		var qrAction string
+
 		if o.Action != nil {
 			qrAction = *o.Action
 		}
 		qAction := qrAction
 		if qAction != "" {
+
 			if err := r.SetQueryParam("action", qAction); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if o.Block != nil {
 
 		// query param block
 		var qrBlock string
+
 		if o.Block != nil {
 			qrBlock = *o.Block
 		}
 		qBlock := qrBlock
 		if qBlock != "" {
+
 			if err := r.SetQueryParam("block", qBlock); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if o.ChainID != nil {
 
 		// query param chainId
 		var qrChainID string
+
 		if o.ChainID != nil {
 			qrChainID = *o.ChainID
 		}
 		qChainID := qrChainID
 		if qChainID != "" {
+
 			if err := r.SetQueryParam("chainId", qChainID); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if o.From != nil {
 
 		// query param from
 		var qrFrom float64
+
 		if o.From != nil {
 			qrFrom = *o.From
 		}
 		qFrom := swag.FormatFloat64(qrFrom)
 		if qFrom != "" {
+
 			if err := r.SetQueryParam("from", qFrom); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if o.Limit != nil {
 
 		// query param limit
 		var qrLimit float64
+
 		if o.Limit != nil {
 			qrLimit = *o.Limit
 		}
 		qLimit := swag.FormatFloat64(qrLimit)
 		if qLimit != "" {
+
 			if err := r.SetQueryParam("limit", qLimit); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if o.Memo != nil {
 
 		// query param memo
 		var qrMemo string
+
 		if o.Memo != nil {
 			qrMemo = *o.Memo
 		}
 		qMemo := qrMemo
 		if qMemo != "" {
+
 			if err := r.SetQueryParam("memo", qMemo); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if o.Offset != nil {
 
 		// query param offset
 		var qrOffset float64
+
 		if o.Offset != nil {
 			qrOffset = *o.Offset
 		}
 		qOffset := swag.FormatFloat64(qrOffset)
 		if qOffset != "" {
+
 			if err := r.SetQueryParam("offset", qOffset); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if o.Order != nil {
 
 		// query param order
 		var qrOrder string
+
 		if o.Order != nil {
 			qrOrder = *o.Order
 		}
 		qOrder := qrOrder
 		if qOrder != "" {
+
 			if err := r.SetQueryParam("order", qOrder); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if o.Page != nil {
 
 		// query param page
 		var qrPage float64
+
 		if o.Page != nil {
 			qrPage = *o.Page
 		}
 		qPage := swag.FormatFloat64(qrPage)
 		if qPage != "" {
+
 			if err := r.SetQueryParam("page", qPage); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if o.To != nil {
 
 		// query param to
 		var qrTo float64
+
 		if o.To != nil {
 			qrTo = *o.To
 		}
 		qTo := swag.FormatFloat64(qrTo)
 		if qTo != "" {
+
 			if err := r.SetQueryParam("to", qTo); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if len(res) > 0 {

--- a/openapi/client/transactions/get_v1_txs_responses.go
+++ b/openapi/client/transactions/get_v1_txs_responses.go
@@ -6,15 +6,15 @@ package transactions
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"fmt"
 	"io"
 
 	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
-	strfmt "github.com/go-openapi/strfmt"
-
-	models "github.com/lidofinance/terra-monitors/openapi/models"
+	"github.com/lidofinance/terra-monitors/openapi/models"
 )
 
 // GetV1TxsReader is a Reader for the GetV1Txs structure.
@@ -37,9 +37,8 @@ func (o *GetV1TxsReader) ReadResponse(response runtime.ClientResponse, consumer 
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -48,7 +47,7 @@ func NewGetV1TxsOK() *GetV1TxsOK {
 	return &GetV1TxsOK{}
 }
 
-/*GetV1TxsOK handles this case with default header values.
+/* GetV1TxsOK describes a response with status code 200, with default header values.
 
 Success
 */
@@ -59,7 +58,6 @@ type GetV1TxsOK struct {
 func (o *GetV1TxsOK) Error() string {
 	return fmt.Sprintf("[GET /v1/txs][%d] getV1TxsOK  %+v", 200, o.Payload)
 }
-
 func (o *GetV1TxsOK) GetPayload() *models.GetTxListResult {
 	return o.Payload
 }
@@ -81,7 +79,7 @@ func NewGetV1TxsBadRequest() *GetV1TxsBadRequest {
 	return &GetV1TxsBadRequest{}
 }
 
-/*GetV1TxsBadRequest handles this case with default header values.
+/* GetV1TxsBadRequest describes a response with status code 400, with default header values.
 
 Error
 */
@@ -92,7 +90,6 @@ type GetV1TxsBadRequest struct {
 func (o *GetV1TxsBadRequest) Error() string {
 	return fmt.Sprintf("[GET /v1/txs][%d] getV1TxsBadRequest  %+v", 400, o.Payload)
 }
-
 func (o *GetV1TxsBadRequest) GetPayload() *GetV1TxsBadRequestBody {
 	return o.Payload
 }
@@ -126,6 +123,11 @@ type GetV1TxsBadRequestBody struct {
 
 // Validate validates this get v1 txs bad request body
 func (o *GetV1TxsBadRequestBody) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this get v1 txs bad request body based on context it is used
+func (o *GetV1TxsBadRequestBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/openapi/client/transactions/transactions_client.go
+++ b/openapi/client/transactions/transactions_client.go
@@ -9,12 +9,11 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
-
-	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new transactions API client.
-func New(transport runtime.ClientTransport, formats strfmt.Registry) *Client {
+func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
 }
 
@@ -26,18 +25,31 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-/*
-GetSlashingValidatorsValidatorPubKeySigningInfo gets validator signing info
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
 
-Get Validator Signing Info
+// ClientService is the interface for Client methods
+type ClientService interface {
+	GetSlashingValidatorsValidatorPubKeySigningInfo(params *GetSlashingValidatorsValidatorPubKeySigningInfoParams, opts ...ClientOption) (*GetSlashingValidatorsValidatorPubKeySigningInfoOK, error)
+
+	GetStakingValidatorsValidatorAddr(params *GetStakingValidatorsValidatorAddrParams, opts ...ClientOption) (*GetStakingValidatorsValidatorAddrOK, error)
+
+	GetV1Txs(params *GetV1TxsParams, opts ...ClientOption) (*GetV1TxsOK, error)
+
+	SetTransport(transport runtime.ClientTransport)
+}
+
+/*
+  GetSlashingValidatorsValidatorPubKeySigningInfo gets validator signing info
+
+  Get Validator Signing Info
 */
-func (a *Client) GetSlashingValidatorsValidatorPubKeySigningInfo(params *GetSlashingValidatorsValidatorPubKeySigningInfoParams) (*GetSlashingValidatorsValidatorPubKeySigningInfoOK, error) {
+func (a *Client) GetSlashingValidatorsValidatorPubKeySigningInfo(params *GetSlashingValidatorsValidatorPubKeySigningInfoParams, opts ...ClientOption) (*GetSlashingValidatorsValidatorPubKeySigningInfoOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetSlashingValidatorsValidatorPubKeySigningInfoParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetSlashingValidatorsValidatorPubKeySigningInfo",
 		Method:             "GET",
 		PathPattern:        "/slashing/validators/{validatorPubKey}/signing_info",
@@ -48,7 +60,12 @@ func (a *Client) GetSlashingValidatorsValidatorPubKeySigningInfo(params *GetSlas
 		Reader:             &GetSlashingValidatorsValidatorPubKeySigningInfoReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -63,17 +80,16 @@ func (a *Client) GetSlashingValidatorsValidatorPubKeySigningInfo(params *GetSlas
 }
 
 /*
-GetStakingValidatorsValidatorAddr gets validator info
+  GetStakingValidatorsValidatorAddr gets validator info
 
-Get validator info
+  Get validator info
 */
-func (a *Client) GetStakingValidatorsValidatorAddr(params *GetStakingValidatorsValidatorAddrParams) (*GetStakingValidatorsValidatorAddrOK, error) {
+func (a *Client) GetStakingValidatorsValidatorAddr(params *GetStakingValidatorsValidatorAddrParams, opts ...ClientOption) (*GetStakingValidatorsValidatorAddrOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetStakingValidatorsValidatorAddrParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetStakingValidatorsValidatorAddr",
 		Method:             "GET",
 		PathPattern:        "/staking/validators/{validatorAddr}",
@@ -84,7 +100,12 @@ func (a *Client) GetStakingValidatorsValidatorAddr(params *GetStakingValidatorsV
 		Reader:             &GetStakingValidatorsValidatorAddrReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -99,17 +120,16 @@ func (a *Client) GetStakingValidatorsValidatorAddr(params *GetStakingValidatorsV
 }
 
 /*
-GetV1Txs gets tx list
+  GetV1Txs gets tx list
 
-Get Tx List
+  Get Tx List
 */
-func (a *Client) GetV1Txs(params *GetV1TxsParams) (*GetV1TxsOK, error) {
+func (a *Client) GetV1Txs(params *GetV1TxsParams, opts ...ClientOption) (*GetV1TxsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetV1TxsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetV1Txs",
 		Method:             "GET",
 		PathPattern:        "/v1/txs",
@@ -120,7 +140,12 @@ func (a *Client) GetV1Txs(params *GetV1TxsParams) (*GetV1TxsOK, error) {
 		Reader:             &GetV1TxsReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/openapi/client/wasm/get_wasm_contracts_contract_address_store_parameters.go
+++ b/openapi/client/wasm/get_wasm_contracts_contract_address_store_parameters.go
@@ -13,68 +13,82 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
-
-	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/strfmt"
 )
 
-// NewGetWasmContractsContractAddressStoreParams creates a new GetWasmContractsContractAddressStoreParams object
-// with the default values initialized.
+// NewGetWasmContractsContractAddressStoreParams creates a new GetWasmContractsContractAddressStoreParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetWasmContractsContractAddressStoreParams() *GetWasmContractsContractAddressStoreParams {
-	var ()
 	return &GetWasmContractsContractAddressStoreParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetWasmContractsContractAddressStoreParamsWithTimeout creates a new GetWasmContractsContractAddressStoreParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetWasmContractsContractAddressStoreParamsWithTimeout(timeout time.Duration) *GetWasmContractsContractAddressStoreParams {
-	var ()
 	return &GetWasmContractsContractAddressStoreParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetWasmContractsContractAddressStoreParamsWithContext creates a new GetWasmContractsContractAddressStoreParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetWasmContractsContractAddressStoreParamsWithContext(ctx context.Context) *GetWasmContractsContractAddressStoreParams {
-	var ()
 	return &GetWasmContractsContractAddressStoreParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetWasmContractsContractAddressStoreParamsWithHTTPClient creates a new GetWasmContractsContractAddressStoreParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetWasmContractsContractAddressStoreParamsWithHTTPClient(client *http.Client) *GetWasmContractsContractAddressStoreParams {
-	var ()
 	return &GetWasmContractsContractAddressStoreParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetWasmContractsContractAddressStoreParams contains all the parameters to send to the API endpoint
-for the get wasm contracts contract address store operation typically these are written to a http.Request
+/* GetWasmContractsContractAddressStoreParams contains all the parameters to send to the API endpoint
+   for the get wasm contracts contract address store operation.
+
+   Typically these are written to a http.Request.
 */
 type GetWasmContractsContractAddressStoreParams struct {
 
-	/*ContractAddress
-	  contract address you want to lookup
+	/* ContractAddress.
 
+	   contract address you want to lookup
 	*/
 	ContractAddress string
-	/*QueryMsg
-	  json formatted query msg
 
+	/* QueryMsg.
+
+	   json formatted query msg
 	*/
 	QueryMsg string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get wasm contracts contract address store params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetWasmContractsContractAddressStoreParams) WithDefaults() *GetWasmContractsContractAddressStoreParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get wasm contracts contract address store params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetWasmContractsContractAddressStoreParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get wasm contracts contract address store params
@@ -149,6 +163,7 @@ func (o *GetWasmContractsContractAddressStoreParams) WriteToRequest(r runtime.Cl
 	qrQueryMsg := o.QueryMsg
 	qQueryMsg := qrQueryMsg
 	if qQueryMsg != "" {
+
 		if err := r.SetQueryParam("query_msg", qQueryMsg); err != nil {
 			return err
 		}

--- a/openapi/client/wasm/get_wasm_contracts_contract_address_store_responses.go
+++ b/openapi/client/wasm/get_wasm_contracts_contract_address_store_responses.go
@@ -6,13 +6,13 @@ package wasm
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"fmt"
 	"io"
 
 	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-
-	strfmt "github.com/go-openapi/strfmt"
 )
 
 // GetWasmContractsContractAddressStoreReader is a Reader for the GetWasmContractsContractAddressStore structure.
@@ -35,9 +35,8 @@ func (o *GetWasmContractsContractAddressStoreReader) ReadResponse(response runti
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -46,7 +45,7 @@ func NewGetWasmContractsContractAddressStoreOK() *GetWasmContractsContractAddres
 	return &GetWasmContractsContractAddressStoreOK{}
 }
 
-/*GetWasmContractsContractAddressStoreOK handles this case with default header values.
+/* GetWasmContractsContractAddressStoreOK describes a response with status code 200, with default header values.
 
 OK
 */
@@ -57,7 +56,6 @@ type GetWasmContractsContractAddressStoreOK struct {
 func (o *GetWasmContractsContractAddressStoreOK) Error() string {
 	return fmt.Sprintf("[GET /wasm/contracts/{contractAddress}/store][%d] getWasmContractsContractAddressStoreOK  %+v", 200, o.Payload)
 }
-
 func (o *GetWasmContractsContractAddressStoreOK) GetPayload() *GetWasmContractsContractAddressStoreOKBody {
 	return o.Payload
 }
@@ -79,7 +77,7 @@ func NewGetWasmContractsContractAddressStoreInternalServerError() *GetWasmContra
 	return &GetWasmContractsContractAddressStoreInternalServerError{}
 }
 
-/*GetWasmContractsContractAddressStoreInternalServerError handles this case with default header values.
+/* GetWasmContractsContractAddressStoreInternalServerError describes a response with status code 500, with default header values.
 
 Error
 */
@@ -90,7 +88,6 @@ type GetWasmContractsContractAddressStoreInternalServerError struct {
 func (o *GetWasmContractsContractAddressStoreInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /wasm/contracts/{contractAddress}/store][%d] getWasmContractsContractAddressStoreInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *GetWasmContractsContractAddressStoreInternalServerError) GetPayload() *GetWasmContractsContractAddressStoreInternalServerErrorBody {
 	return o.Payload
 }
@@ -118,6 +115,11 @@ type GetWasmContractsContractAddressStoreInternalServerErrorBody struct {
 
 // Validate validates this get wasm contracts contract address store internal server error body
 func (o *GetWasmContractsContractAddressStoreInternalServerErrorBody) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this get wasm contracts contract address store internal server error body based on context it is used
+func (o *GetWasmContractsContractAddressStoreInternalServerErrorBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 
@@ -153,6 +155,11 @@ type GetWasmContractsContractAddressStoreOKBody struct {
 
 // Validate validates this get wasm contracts contract address store o k body
 func (o *GetWasmContractsContractAddressStoreOKBody) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this get wasm contracts contract address store o k body based on context it is used
+func (o *GetWasmContractsContractAddressStoreOKBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/openapi/client/wasm/wasm_swagger_client.go
+++ b/openapi/client/wasm/wasm_swagger_client.go
@@ -9,12 +9,11 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
-
-	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new wasm API client.
-func New(transport runtime.ClientTransport, formats strfmt.Registry) *Client {
+func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
 }
 
@@ -26,27 +25,41 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
+// ClientService is the interface for Client methods
+type ClientService interface {
+	GetWasmContractsContractAddressStore(params *GetWasmContractsContractAddressStoreParams, opts ...ClientOption) (*GetWasmContractsContractAddressStoreOK, error)
+
+	SetTransport(transport runtime.ClientTransport)
+}
+
 /*
-GetWasmContractsContractAddressStore gets stored information with query msg
+  GetWasmContractsContractAddressStore gets stored information with query msg
 */
-func (a *Client) GetWasmContractsContractAddressStore(params *GetWasmContractsContractAddressStoreParams) (*GetWasmContractsContractAddressStoreOK, error) {
+func (a *Client) GetWasmContractsContractAddressStore(params *GetWasmContractsContractAddressStoreParams, opts ...ClientOption) (*GetWasmContractsContractAddressStoreOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetWasmContractsContractAddressStoreParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetWasmContractsContractAddressStore",
 		Method:             "GET",
 		PathPattern:        "/wasm/contracts/{contractAddress}/store",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{""},
+		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GetWasmContractsContractAddressStoreReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/openapi/models/get_tx_list_result.go
+++ b/openapi/models/get_tx_list_result.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResult get tx list result
+//
 // swagger:model getTxListResult
 type GetTxListResult struct {
 
@@ -85,6 +86,38 @@ func (m *GetTxListResult) validateTxs(formats strfmt.Registry) error {
 
 		if m.Txs[i] != nil {
 			if err := m.Txs[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("txs" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx list result based on the context it is used
+func (m *GetTxListResult) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateTxs(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxListResult) contextValidateTxs(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Txs); i++ {
+
+		if m.Txs[i] != nil {
+			if err := m.Txs[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("txs" + "." + strconv.Itoa(i))
 				}

--- a/openapi/models/get_tx_list_result_txs.go
+++ b/openapi/models/get_tx_list_result_txs.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxs get tx list result txs
+//
 // swagger:model getTxListResult.txs
 type GetTxListResultTxs struct {
 
@@ -236,6 +237,78 @@ func (m *GetTxListResultTxs) validateTxhash(formats strfmt.Registry) error {
 
 	if err := validate.Required("txhash", "body", m.Txhash); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx list result txs based on the context it is used
+func (m *GetTxListResultTxs) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateEvents(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateLogs(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateTx(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxListResultTxs) contextValidateEvents(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Events); i++ {
+
+		if m.Events[i] != nil {
+			if err := m.Events[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("events" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *GetTxListResultTxs) contextValidateLogs(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Logs); i++ {
+
+		if m.Logs[i] != nil {
+			if err := m.Logs[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("logs" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *GetTxListResultTxs) contextValidateTx(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Tx != nil {
+		if err := m.Tx.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("tx")
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/openapi/models/get_tx_list_result_txs_events.go
+++ b/openapi/models/get_tx_list_result_txs_events.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsEvents get tx list result txs events
+//
 // swagger:model getTxListResult.txs.events
 type GetTxListResultTxsEvents struct {
 
@@ -75,6 +76,38 @@ func (m *GetTxListResultTxsEvents) validateType(formats strfmt.Registry) error {
 
 	if err := validate.Required("type", "body", m.Type); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx list result txs events based on the context it is used
+func (m *GetTxListResultTxsEvents) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateAttributes(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxListResultTxsEvents) contextValidateAttributes(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Attributes); i++ {
+
+		if m.Attributes[i] != nil {
+			if err := m.Attributes[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("attributes" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
 	}
 
 	return nil

--- a/openapi/models/get_tx_list_result_txs_events_attributes.go
+++ b/openapi/models/get_tx_list_result_txs_events_attributes.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsEventsAttributes get tx list result txs events attributes
+//
 // swagger:model getTxListResult.txs.events.attributes
 type GetTxListResultTxsEventsAttributes struct {
 
@@ -59,6 +61,11 @@ func (m *GetTxListResultTxsEventsAttributes) validateValue(formats strfmt.Regist
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this get tx list result txs events attributes based on context it is used
+func (m *GetTxListResultTxsEventsAttributes) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/openapi/models/get_tx_list_result_txs_logs.go
+++ b/openapi/models/get_tx_list_result_txs_logs.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsLogs get tx list result txs logs
+//
 // swagger:model getTxListResult.txs.logs
 type GetTxListResultTxsLogs struct {
 
@@ -118,6 +119,56 @@ func (m *GetTxListResultTxsLogs) validateSuccess(formats strfmt.Registry) error 
 
 	if err := validate.Required("success", "body", m.Success); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx list result txs logs based on the context it is used
+func (m *GetTxListResultTxsLogs) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateEvents(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateLog(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxListResultTxsLogs) contextValidateEvents(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Events); i++ {
+
+		if m.Events[i] != nil {
+			if err := m.Events[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("events" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *GetTxListResultTxsLogs) contextValidateLog(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Log != nil {
+		if err := m.Log.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("log")
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/openapi/models/get_tx_list_result_txs_logs_events.go
+++ b/openapi/models/get_tx_list_result_txs_logs_events.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsLogsEvents get tx list result txs logs events
+//
 // swagger:model getTxListResult.txs.logs.events
 type GetTxListResultTxsLogsEvents struct {
 
@@ -75,6 +76,38 @@ func (m *GetTxListResultTxsLogsEvents) validateType(formats strfmt.Registry) err
 
 	if err := validate.Required("type", "body", m.Type); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx list result txs logs events based on the context it is used
+func (m *GetTxListResultTxsLogsEvents) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateAttributes(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxListResultTxsLogsEvents) contextValidateAttributes(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Attributes); i++ {
+
+		if m.Attributes[i] != nil {
+			if err := m.Attributes[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("attributes" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
 	}
 
 	return nil

--- a/openapi/models/get_tx_list_result_txs_logs_events_attributes.go
+++ b/openapi/models/get_tx_list_result_txs_logs_events_attributes.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsLogsEventsAttributes get tx list result txs logs events attributes
+//
 // swagger:model getTxListResult.txs.logs.events.attributes
 type GetTxListResultTxsLogsEventsAttributes struct {
 
@@ -59,6 +61,11 @@ func (m *GetTxListResultTxsLogsEventsAttributes) validateValue(formats strfmt.Re
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this get tx list result txs logs events attributes based on context it is used
+func (m *GetTxListResultTxsLogsEventsAttributes) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/openapi/models/get_tx_list_result_txs_logs_log.go
+++ b/openapi/models/get_tx_list_result_txs_logs_log.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsLogsLog get tx list result txs logs log
+//
 // swagger:model getTxListResult.txs.logs.log
 type GetTxListResultTxsLogsLog struct {
 
@@ -42,6 +44,11 @@ func (m *GetTxListResultTxsLogsLog) validateTax(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this get tx list result txs logs log based on context it is used
+func (m *GetTxListResultTxsLogsLog) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/openapi/models/get_tx_list_result_txs_tx.go
+++ b/openapi/models/get_tx_list_result_txs_tx.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsTx get tx list result txs tx
+//
 // swagger:model getTxListResult.txs.tx
 type GetTxListResultTxsTx struct {
 
@@ -61,6 +63,34 @@ func (m *GetTxListResultTxsTx) validateValue(formats strfmt.Registry) error {
 
 	if m.Value != nil {
 		if err := m.Value.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("value")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx list result txs tx based on the context it is used
+func (m *GetTxListResultTxsTx) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateValue(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxListResultTxsTx) contextValidateValue(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Value != nil {
+		if err := m.Value.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("value")
 			}

--- a/openapi/models/get_tx_list_result_txs_tx_value.go
+++ b/openapi/models/get_tx_list_result_txs_tx_value.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsTxValue get tx list result txs tx value
+//
 // swagger:model getTxListResult.txs.tx.value
 type GetTxListResultTxsTxValue struct {
 
@@ -127,6 +128,78 @@ func (m *GetTxListResultTxsTxValue) validateSignatures(formats strfmt.Registry) 
 
 		if m.Signatures[i] != nil {
 			if err := m.Signatures[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("signatures" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx list result txs tx value based on the context it is used
+func (m *GetTxListResultTxsTxValue) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateFee(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateMsg(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateSignatures(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxListResultTxsTxValue) contextValidateFee(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Fee != nil {
+		if err := m.Fee.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("fee")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *GetTxListResultTxsTxValue) contextValidateMsg(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Msg); i++ {
+
+		if m.Msg[i] != nil {
+			if err := m.Msg[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("msg" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *GetTxListResultTxsTxValue) contextValidateSignatures(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Signatures); i++ {
+
+		if m.Signatures[i] != nil {
+			if err := m.Signatures[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("signatures" + "." + strconv.Itoa(i))
 				}

--- a/openapi/models/get_tx_list_result_txs_tx_value_fee.go
+++ b/openapi/models/get_tx_list_result_txs_tx_value_fee.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsTxValueFee get tx list result txs tx value fee
+//
 // swagger:model getTxListResult.txs.tx.value.fee
 type GetTxListResultTxsTxValueFee struct {
 
@@ -75,6 +76,38 @@ func (m *GetTxListResultTxsTxValueFee) validateGas(formats strfmt.Registry) erro
 
 	if err := validate.Required("gas", "body", m.Gas); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx list result txs tx value fee based on the context it is used
+func (m *GetTxListResultTxsTxValueFee) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateAmount(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxListResultTxsTxValueFee) contextValidateAmount(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Amount); i++ {
+
+		if m.Amount[i] != nil {
+			if err := m.Amount[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("amount" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
 	}
 
 	return nil

--- a/openapi/models/get_tx_list_result_txs_tx_value_fee_amount.go
+++ b/openapi/models/get_tx_list_result_txs_tx_value_fee_amount.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsTxValueFeeAmount get tx list result txs tx value fee amount
+//
 // swagger:model getTxListResult.txs.tx.value.fee.amount
 type GetTxListResultTxsTxValueFeeAmount struct {
 
@@ -59,6 +61,11 @@ func (m *GetTxListResultTxsTxValueFeeAmount) validateDenom(formats strfmt.Regist
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this get tx list result txs tx value fee amount based on context it is used
+func (m *GetTxListResultTxsTxValueFeeAmount) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/openapi/models/get_tx_list_result_txs_tx_value_msg.go
+++ b/openapi/models/get_tx_list_result_txs_tx_value_msg.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsTxValueMsg get tx list result txs tx value msg
+//
 // swagger:model getTxListResult.txs.tx.value.msg
 type GetTxListResultTxsTxValueMsg struct {
 
@@ -61,6 +63,34 @@ func (m *GetTxListResultTxsTxValueMsg) validateValue(formats strfmt.Registry) er
 
 	if m.Value != nil {
 		if err := m.Value.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("value")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx list result txs tx value msg based on the context it is used
+func (m *GetTxListResultTxsTxValueMsg) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateValue(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxListResultTxsTxValueMsg) contextValidateValue(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Value != nil {
+		if err := m.Value.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("value")
 			}

--- a/openapi/models/get_tx_list_result_txs_tx_value_msg_value.go
+++ b/openapi/models/get_tx_list_result_txs_tx_value_msg_value.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsTxValueMsgValue get tx list result txs tx value msg value
+//
 // swagger:model getTxListResult.txs.tx.value.msg.value
 type GetTxListResultTxsTxValueMsgValue struct {
 
@@ -109,6 +110,38 @@ func (m *GetTxListResultTxsTxValueMsgValue) validateSender(formats strfmt.Regist
 
 	if err := validate.Required("sender", "body", m.Sender); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx list result txs tx value msg value based on the context it is used
+func (m *GetTxListResultTxsTxValueMsgValue) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateCoins(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxListResultTxsTxValueMsgValue) contextValidateCoins(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Coins); i++ {
+
+		if m.Coins[i] != nil {
+			if err := m.Coins[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("coins" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
 	}
 
 	return nil

--- a/openapi/models/get_tx_list_result_txs_tx_value_msg_value_inputs.go
+++ b/openapi/models/get_tx_list_result_txs_tx_value_msg_value_inputs.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsTxValueMsgValueInputs get tx list result txs tx value msg value inputs
+//
 // swagger:model getTxListResult.txs.tx.value.msg.value.inputs
 type GetTxListResultTxsTxValueMsgValueInputs struct {
 
@@ -68,6 +69,38 @@ func (m *GetTxListResultTxsTxValueMsgValueInputs) validateCoins(formats strfmt.R
 
 		if m.Coins[i] != nil {
 			if err := m.Coins[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("coins" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx list result txs tx value msg value inputs based on the context it is used
+func (m *GetTxListResultTxsTxValueMsgValueInputs) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateCoins(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxListResultTxsTxValueMsgValueInputs) contextValidateCoins(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Coins); i++ {
+
+		if m.Coins[i] != nil {
+			if err := m.Coins[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("coins" + "." + strconv.Itoa(i))
 				}

--- a/openapi/models/get_tx_list_result_txs_tx_value_msg_value_inputs_coins.go
+++ b/openapi/models/get_tx_list_result_txs_tx_value_msg_value_inputs_coins.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsTxValueMsgValueInputsCoins get tx list result txs tx value msg value inputs coins
+//
 // swagger:model getTxListResult.txs.tx.value.msg.value.inputs.coins
 type GetTxListResultTxsTxValueMsgValueInputsCoins struct {
 
@@ -59,6 +61,11 @@ func (m *GetTxListResultTxsTxValueMsgValueInputsCoins) validateDeonm(formats str
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this get tx list result txs tx value msg value inputs coins based on context it is used
+func (m *GetTxListResultTxsTxValueMsgValueInputsCoins) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/openapi/models/get_tx_list_result_txs_tx_value_msg_value_outputs.go
+++ b/openapi/models/get_tx_list_result_txs_tx_value_msg_value_outputs.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsTxValueMsgValueOutputs get tx list result txs tx value msg value outputs
+//
 // swagger:model getTxListResult.txs.tx.value.msg.value.outputs
 type GetTxListResultTxsTxValueMsgValueOutputs struct {
 
@@ -68,6 +69,38 @@ func (m *GetTxListResultTxsTxValueMsgValueOutputs) validateCoins(formats strfmt.
 
 		if m.Coins[i] != nil {
 			if err := m.Coins[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("coins" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx list result txs tx value msg value outputs based on the context it is used
+func (m *GetTxListResultTxsTxValueMsgValueOutputs) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateCoins(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxListResultTxsTxValueMsgValueOutputs) contextValidateCoins(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Coins); i++ {
+
+		if m.Coins[i] != nil {
+			if err := m.Coins[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("coins" + "." + strconv.Itoa(i))
 				}

--- a/openapi/models/get_tx_list_result_txs_tx_value_msg_value_outputs_coins.go
+++ b/openapi/models/get_tx_list_result_txs_tx_value_msg_value_outputs_coins.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsTxValueMsgValueOutputsCoins get tx list result txs tx value msg value outputs coins
+//
 // swagger:model getTxListResult.txs.tx.value.msg.value.outputs.coins
 type GetTxListResultTxsTxValueMsgValueOutputsCoins struct {
 
@@ -59,6 +61,11 @@ func (m *GetTxListResultTxsTxValueMsgValueOutputsCoins) validateDeonm(formats st
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this get tx list result txs tx value msg value outputs coins based on context it is used
+func (m *GetTxListResultTxsTxValueMsgValueOutputsCoins) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/openapi/models/get_tx_list_result_txs_tx_value_signatures.go
+++ b/openapi/models/get_tx_list_result_txs_tx_value_signatures.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsTxValueSignatures get tx list result txs tx value signatures
+//
 // swagger:model getTxListResult.txs.tx.value.signatures
 type GetTxListResultTxsTxValueSignatures struct {
 
@@ -66,6 +68,34 @@ func (m *GetTxListResultTxsTxValueSignatures) validateSignature(formats strfmt.R
 
 	if err := validate.Required("signature", "body", m.Signature); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx list result txs tx value signatures based on the context it is used
+func (m *GetTxListResultTxsTxValueSignatures) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidatePubKey(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxListResultTxsTxValueSignatures) contextValidatePubKey(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.PubKey != nil {
+		if err := m.PubKey.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("pub_key")
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/openapi/models/get_tx_list_result_txs_tx_value_signatures_pub_key.go
+++ b/openapi/models/get_tx_list_result_txs_tx_value_signatures_pub_key.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxListResultTxsTxValueSignaturesPubKey get tx list result txs tx value signatures pub key
+//
 // swagger:model getTxListResult.txs.tx.value.signatures.pub_key
 type GetTxListResultTxsTxValueSignaturesPubKey struct {
 
@@ -59,6 +61,11 @@ func (m *GetTxListResultTxsTxValueSignaturesPubKey) validateValue(formats strfmt
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this get tx list result txs tx value signatures pub key based on context it is used
+func (m *GetTxListResultTxsTxValueSignaturesPubKey) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/openapi/models/get_tx_result.go
+++ b/openapi/models/get_tx_result.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxResult get tx result
+//
 // swagger:model getTxResult
 type GetTxResult struct {
 
@@ -236,6 +237,78 @@ func (m *GetTxResult) validateTxhash(formats strfmt.Registry) error {
 
 	if err := validate.Required("txhash", "body", m.Txhash); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx result based on the context it is used
+func (m *GetTxResult) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateEvents(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateLogs(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateTx(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxResult) contextValidateEvents(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Events); i++ {
+
+		if m.Events[i] != nil {
+			if err := m.Events[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("events" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *GetTxResult) contextValidateLogs(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Logs); i++ {
+
+		if m.Logs[i] != nil {
+			if err := m.Logs[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("logs" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *GetTxResult) contextValidateTx(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Tx != nil {
+		if err := m.Tx.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("tx")
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/openapi/models/get_tx_result_events.go
+++ b/openapi/models/get_tx_result_events.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxResultEvents get tx result events
+//
 // swagger:model getTxResult.events
 type GetTxResultEvents struct {
 
@@ -75,6 +76,38 @@ func (m *GetTxResultEvents) validateType(formats strfmt.Registry) error {
 
 	if err := validate.Required("type", "body", m.Type); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx result events based on the context it is used
+func (m *GetTxResultEvents) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateAttributes(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxResultEvents) contextValidateAttributes(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Attributes); i++ {
+
+		if m.Attributes[i] != nil {
+			if err := m.Attributes[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("attributes" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
 	}
 
 	return nil

--- a/openapi/models/get_tx_result_events_attributes.go
+++ b/openapi/models/get_tx_result_events_attributes.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxResultEventsAttributes get tx result events attributes
+//
 // swagger:model getTxResult.events.attributes
 type GetTxResultEventsAttributes struct {
 
@@ -59,6 +61,11 @@ func (m *GetTxResultEventsAttributes) validateValue(formats strfmt.Registry) err
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this get tx result events attributes based on context it is used
+func (m *GetTxResultEventsAttributes) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/openapi/models/get_tx_result_logs.go
+++ b/openapi/models/get_tx_result_logs.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxResultLogs get tx result logs
+//
 // swagger:model getTxResult.logs
 type GetTxResultLogs struct {
 
@@ -118,6 +119,56 @@ func (m *GetTxResultLogs) validateSuccess(formats strfmt.Registry) error {
 
 	if err := validate.Required("success", "body", m.Success); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx result logs based on the context it is used
+func (m *GetTxResultLogs) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateEvents(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateLog(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxResultLogs) contextValidateEvents(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Events); i++ {
+
+		if m.Events[i] != nil {
+			if err := m.Events[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("events" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *GetTxResultLogs) contextValidateLog(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Log != nil {
+		if err := m.Log.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("log")
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/openapi/models/get_tx_result_logs_events.go
+++ b/openapi/models/get_tx_result_logs_events.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxResultLogsEvents get tx result logs events
+//
 // swagger:model getTxResult.logs.events
 type GetTxResultLogsEvents struct {
 
@@ -75,6 +76,38 @@ func (m *GetTxResultLogsEvents) validateTypes(formats strfmt.Registry) error {
 
 	if err := validate.Required("types", "body", m.Types); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx result logs events based on the context it is used
+func (m *GetTxResultLogsEvents) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateAttributes(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxResultLogsEvents) contextValidateAttributes(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Attributes); i++ {
+
+		if m.Attributes[i] != nil {
+			if err := m.Attributes[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("attributes" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
 	}
 
 	return nil

--- a/openapi/models/get_tx_result_logs_events_attributes.go
+++ b/openapi/models/get_tx_result_logs_events_attributes.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxResultLogsEventsAttributes get tx result logs events attributes
+//
 // swagger:model getTxResult.logs.events.attributes
 type GetTxResultLogsEventsAttributes struct {
 
@@ -59,6 +61,11 @@ func (m *GetTxResultLogsEventsAttributes) validateValue(formats strfmt.Registry)
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this get tx result logs events attributes based on context it is used
+func (m *GetTxResultLogsEventsAttributes) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/openapi/models/get_tx_result_logs_log.go
+++ b/openapi/models/get_tx_result_logs_log.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxResultLogsLog get tx result logs log
+//
 // swagger:model getTxResult.logs.log
 type GetTxResultLogsLog struct {
 
@@ -42,6 +44,11 @@ func (m *GetTxResultLogsLog) validateTax(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this get tx result logs log based on context it is used
+func (m *GetTxResultLogsLog) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/openapi/models/get_tx_result_tx.go
+++ b/openapi/models/get_tx_result_tx.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxResultTx get tx result tx
+//
 // swagger:model getTxResult.tx
 type GetTxResultTx struct {
 
@@ -61,6 +63,34 @@ func (m *GetTxResultTx) validateValue(formats strfmt.Registry) error {
 
 	if m.Value != nil {
 		if err := m.Value.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("value")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx result tx based on the context it is used
+func (m *GetTxResultTx) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateValue(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxResultTx) contextValidateValue(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Value != nil {
+		if err := m.Value.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("value")
 			}

--- a/openapi/models/get_tx_result_tx_value.go
+++ b/openapi/models/get_tx_result_tx_value.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxResultTxValue get tx result tx value
+//
 // swagger:model getTxResult.tx.value
 type GetTxResultTxValue struct {
 
@@ -127,6 +128,78 @@ func (m *GetTxResultTxValue) validateSignatures(formats strfmt.Registry) error {
 
 		if m.Signatures[i] != nil {
 			if err := m.Signatures[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("signatures" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx result tx value based on the context it is used
+func (m *GetTxResultTxValue) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateFee(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateMsg(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateSignatures(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxResultTxValue) contextValidateFee(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Fee != nil {
+		if err := m.Fee.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("fee")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *GetTxResultTxValue) contextValidateMsg(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Msg); i++ {
+
+		if m.Msg[i] != nil {
+			if err := m.Msg[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("msg" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *GetTxResultTxValue) contextValidateSignatures(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Signatures); i++ {
+
+		if m.Signatures[i] != nil {
+			if err := m.Signatures[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("signatures" + "." + strconv.Itoa(i))
 				}

--- a/openapi/models/get_tx_result_tx_value_fee.go
+++ b/openapi/models/get_tx_result_tx_value_fee.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxResultTxValueFee get tx result tx value fee
+//
 // swagger:model getTxResult.tx.value.fee
 type GetTxResultTxValueFee struct {
 
@@ -75,6 +76,38 @@ func (m *GetTxResultTxValueFee) validateGas(formats strfmt.Registry) error {
 
 	if err := validate.Required("gas", "body", m.Gas); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx result tx value fee based on the context it is used
+func (m *GetTxResultTxValueFee) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateAmount(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxResultTxValueFee) contextValidateAmount(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Amount); i++ {
+
+		if m.Amount[i] != nil {
+			if err := m.Amount[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("amount" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
 	}
 
 	return nil

--- a/openapi/models/get_tx_result_tx_value_fee_amount.go
+++ b/openapi/models/get_tx_result_tx_value_fee_amount.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxResultTxValueFeeAmount get tx result tx value fee amount
+//
 // swagger:model getTxResult.tx.value.fee.amount
 type GetTxResultTxValueFeeAmount struct {
 
@@ -59,6 +61,11 @@ func (m *GetTxResultTxValueFeeAmount) validateDenom(formats strfmt.Registry) err
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this get tx result tx value fee amount based on context it is used
+func (m *GetTxResultTxValueFeeAmount) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/openapi/models/get_tx_result_tx_value_msg.go
+++ b/openapi/models/get_tx_result_tx_value_msg.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxResultTxValueMsg get tx result tx value msg
+//
 // swagger:model getTxResult.tx.value.msg
 type GetTxResultTxValueMsg struct {
 
@@ -61,6 +63,34 @@ func (m *GetTxResultTxValueMsg) validateValue(formats strfmt.Registry) error {
 
 	if m.Value != nil {
 		if err := m.Value.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("value")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx result tx value msg based on the context it is used
+func (m *GetTxResultTxValueMsg) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateValue(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxResultTxValueMsg) contextValidateValue(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Value != nil {
+		if err := m.Value.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("value")
 			}

--- a/openapi/models/get_tx_result_tx_value_msg_value.go
+++ b/openapi/models/get_tx_result_tx_value_msg_value.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxResultTxValueMsgValue get tx result tx value msg value
+//
 // swagger:model getTxResult.tx.value.msg.value
 type GetTxResultTxValueMsgValue struct {
 
@@ -51,6 +52,38 @@ func (m *GetTxResultTxValueMsgValue) validateAmount(formats strfmt.Registry) err
 
 		if m.Amount[i] != nil {
 			if err := m.Amount[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("amount" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx result tx value msg value based on the context it is used
+func (m *GetTxResultTxValueMsgValue) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateAmount(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxResultTxValueMsgValue) contextValidateAmount(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Amount); i++ {
+
+		if m.Amount[i] != nil {
+			if err := m.Amount[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("amount" + "." + strconv.Itoa(i))
 				}

--- a/openapi/models/get_tx_result_tx_value_msg_value_amount.go
+++ b/openapi/models/get_tx_result_tx_value_msg_value_amount.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxResultTxValueMsgValueAmount get tx result tx value msg value amount
+//
 // swagger:model getTxResult.tx.value.msg.value.amount
 type GetTxResultTxValueMsgValueAmount struct {
 
@@ -59,6 +61,11 @@ func (m *GetTxResultTxValueMsgValueAmount) validateDenom(formats strfmt.Registry
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this get tx result tx value msg value amount based on context it is used
+func (m *GetTxResultTxValueMsgValueAmount) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/openapi/models/get_tx_result_tx_value_signatures.go
+++ b/openapi/models/get_tx_result_tx_value_signatures.go
@@ -6,16 +6,17 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
-	strfmt "github.com/go-openapi/strfmt"
-
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxResultTxValueSignatures get tx result tx value signatures
+//
 // swagger:model getTxResult.tx.value.signatures
 type GetTxResultTxValueSignatures struct {
 
@@ -75,6 +76,38 @@ func (m *GetTxResultTxValueSignatures) validateSignature(formats strfmt.Registry
 
 	if err := validate.Required("signature", "body", m.Signature); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get tx result tx value signatures based on the context it is used
+func (m *GetTxResultTxValueSignatures) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidatePubKey(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *GetTxResultTxValueSignatures) contextValidatePubKey(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.PubKey); i++ {
+
+		if m.PubKey[i] != nil {
+			if err := m.PubKey[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("pubKey" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
 	}
 
 	return nil

--- a/openapi/models/get_tx_result_tx_value_signatures_pub_key.go
+++ b/openapi/models/get_tx_result_tx_value_signatures_pub_key.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // GetTxResultTxValueSignaturesPubKey get tx result tx value signatures pub key
+//
 // swagger:model getTxResult.tx.value.signatures.pubKey
 type GetTxResultTxValueSignaturesPubKey struct {
 
@@ -59,6 +61,11 @@ func (m *GetTxResultTxValueSignaturesPubKey) validateValue(formats strfmt.Regist
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this get tx result tx value signatures pub key based on context it is used
+func (m *GetTxResultTxValueSignaturesPubKey) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/openapi/models/signing_info.go
+++ b/openapi/models/signing_info.go
@@ -6,14 +6,16 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // SigningInfo signing info
+//
 // swagger:model SigningInfo
 type SigningInfo struct {
 
@@ -127,6 +129,11 @@ func (m *SigningInfo) validateTombstoned(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this signing info based on context it is used
+func (m *SigningInfo) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/openapi/models/validator_info.go
+++ b/openapi/models/validator_info.go
@@ -6,20 +6,26 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	strfmt "github.com/go-openapi/strfmt"
+	"context"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // ValidatorInfo validator info
+//
 // swagger:model ValidatorInfo
 type ValidatorInfo struct {
 
 	// consensus pubkey
 	// Required: true
 	ConsensusPubkey *string `json:"consensus_pubkey"`
+
+	// description
+	// Required: true
+	Description *ValidatorInfoDescription `json:"description"`
 }
 
 // Validate validates this validator info
@@ -27,6 +33,10 @@ func (m *ValidatorInfo) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateConsensusPubkey(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateDescription(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -45,6 +55,52 @@ func (m *ValidatorInfo) validateConsensusPubkey(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *ValidatorInfo) validateDescription(formats strfmt.Registry) error {
+
+	if err := validate.Required("description", "body", m.Description); err != nil {
+		return err
+	}
+
+	if m.Description != nil {
+		if err := m.Description.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("description")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this validator info based on the context it is used
+func (m *ValidatorInfo) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateDescription(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *ValidatorInfo) contextValidateDescription(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Description != nil {
+		if err := m.Description.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("description")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 // MarshalBinary interface implementation
 func (m *ValidatorInfo) MarshalBinary() ([]byte, error) {
 	if m == nil {
@@ -56,6 +112,43 @@ func (m *ValidatorInfo) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *ValidatorInfo) UnmarshalBinary(b []byte) error {
 	var res ValidatorInfo
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// ValidatorInfoDescription validator info description
+//
+// swagger:model ValidatorInfoDescription
+type ValidatorInfoDescription struct {
+
+	// moniker
+	Moniker string `json:"moniker,omitempty"`
+}
+
+// Validate validates this validator info description
+func (m *ValidatorInfoDescription) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this validator info description based on context it is used
+func (m *ValidatorInfoDescription) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *ValidatorInfoDescription) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *ValidatorInfoDescription) UnmarshalBinary(b []byte) error {
+	var res ValidatorInfoDescription
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -818,5 +818,11 @@ definitions:
     properties:
       consensus_pubkey:
         type: string
+      description:
+        type: object
+        properties:
+          moniker:
+            type: string
     required:
       - consensus_pubkey
+      - description


### PR DESCRIPTION
i've added a new methods to ValidatorsRepository, Monitor and Collector interfaces, to provide a labeled gauges for prometheus.

GetMetricVectors() map[Metric]map[string]float64 
added for Monitor

DisplayName(string) string
added for ValidatorsRepository

and 
GetVector(metric monitors.Metric) (map[string]float64, error)
ProvidedMetricVectors() []monitors.Metric
added for collector.

as a result we have
![Screenshot_20210804_131701](https://user-images.githubusercontent.com/62722506/128170636-03c294da-c9b0-4ac5-850a-dabd236e320f.png)

on the screenshot you can see contracts public keys as labels. The DisplayName on validatorsRepository is responsible for the labels.