### PR TITLE
[WIP] fix: telegram notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@
 .vscode
 .telegram.env
 .lido_terra.env
+.grafana.env
 
 .idea/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # terra-monitors
 
+There are required three .env files to start service:
+`./docker/env/.telegram.env` - telegramm bot credentials
+`./docker/env/.lido_terra.env` - terra-monitor service settings
+`./docker/env/.grafana.env` - grafana related variables
+
 Before running the service you have to fill .env file `./docker/env/.telegram.env` with the following variables:
 ```shell
 cat ./docker/env/.telegram.env 
@@ -33,6 +38,13 @@ ADDRESSES_AIR_DROP_REGISTRY_CONTRACT=terra_dummy_airdrop
 ADDRESSES_UPDATE_GLOBAL_INDEX_BOT_ADDRESS=terra1eqpx4zr2vm9jwu2vas5rh6704f6zzglsayf2fy
 ```
 
+To set relevant grafana address in alert messages, put env variable `GF_SERVER_ROOT_URL` with URL in `./docker/env/.grafana.env` file
+```shell
+cat ./docker/env/.grafana.env 
+GF_SERVER_ROOT_URL=http://some-host/
+```
+
+
 To run the service
 ```shell
 make start
@@ -44,6 +56,12 @@ make stop
 ```
 
 Grafana dashboards avaliable at http://127.0.0.1:3000.
+To change default port of the grafana host, pass variable `GRAFANA_PORT` to start command, lile:
+```shell
+GRAFANA_PORT=3001 make start
+#or
+GRAFANA_PORT=3001 docker-compose up -d
+```
 
 Default login/pass: `admin/admin`.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # terra-monitors
 
-There are required three .env files to start service:
-`./docker/env/.telegram.env` - telegramm bot credentials
-`./docker/env/.lido_terra.env` - terra-monitor service settings
+There are required three .env files to start service:\
+`./docker/env/.telegram.env` - telegramm bot credentials\
+`./docker/env/.lido_terra.env` - terra-monitor service settings\
 `./docker/env/.grafana.env` - grafana related variables
 
 Before running the service you have to fill .env file `./docker/env/.telegram.env` with the following variables:

--- a/README.md
+++ b/README.md
@@ -9,16 +9,27 @@ TELEGRAM_CHAT_ID=<telegram_chat_id>
 
 Before running the service you have to fill .env file `./docker/env/.lido_terra.env` with the following variables:
 ```shell
-cat ./docker/env/.lido_terra.env 
+cat ./docker/env/.lido_terra.env
+# Grafana frontend port - optional value, default value is 3000
+GRAFANA_PORT=3000 
+
+# LCD - light client daemon, https://docs.terra.money/terracli/lcd.html
 LCD_ENDPOINT=fcd.terra.dev
 LCD_SCHEMES=https
+
+# terra-monitor data update interval
 UPDATE_DATA_INTERVAL=30s
+
+# monitored contracts
 ADDRESSES_HUB_CONTRACT=terra1mtwph2juhj0rvjz7dy92gvl6xvukaxu8rfv8ts
 ADDRESSES_REWARD_CONTRACT=terra17yap3mhph35pcwvhza38c2lkj7gzywzy05h7l0
 ADDRESSES_BLUNA_TOKEN_INFO_CONTRACT=terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp
 ADDRESSES_VALIDATORS_REGISTRY_CONTRACT=terra_dummy_validators_registry
 ADDRESSES_REWARDS_DISPATCHER_CONTRACT=terra_dummy_rewards_dispatcher
 ADDRESSES_AIR_DROP_REGISTRY_CONTRACT=terra_dummy_airdrop
+
+# monitored bot, executing update_global_index message on the hub contract
+# https://www.notion.so/bAsset-index-updating-bot-f64ebb5ec6704f05a840d93f28b1e3be
 ADDRESSES_UPDATE_GLOBAL_INDEX_BOT_ADDRESS=terra1eqpx4zr2vm9jwu2vas5rh6704f6zzglsayf2fy
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   grafana:
     image: grafana/grafana:8.0.5
     ports:
-      - "3000:3000"
+      - "${GRAFANA_PORT:-3000}:3000"
     depends_on:
       - prometheus
     env_file:
@@ -16,14 +16,10 @@ services:
       - grafana-storage:/var/lib/grafana
   renderer:
     image: grafana/grafana-image-renderer:latest
-    ports:
-      - 8081
     environment:
       ENABLE_METRICS: 'true'
   prometheus:
     image: prom/prometheus
-    ports:
-      - 9090:9090
     command:
       - --config.file=/etc/prometheus/prometheus.yml
     volumes:
@@ -43,8 +39,6 @@ services:
     image: grafana/loki:2.3.0
     volumes:
       - loki-data:/loki
-    ports:
-      - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     depends_on:
       - prometheus
     env_file:
-      ./docker/env/.telegram.env
+      - ./docker/env/.telegram.env
+      - ./docker/env/.grafana.env
     environment:
       - GF_RENDERING_SERVER_URL=http://renderer:8081/render
       - GF_RENDERING_CALLBACK_URL=http://grafana:3000/


### PR DESCRIPTION
to set relevant monitoring endpoint we can put variable GF_SERVER_ROOT_URL in .grafana.env file
```shell
GF_SERVER_ROOT_URL=http://swelf-host:3000
```
notification will look
![Screenshot_20210826_140357](https://user-images.githubusercontent.com/62722506/130951800-1e2ef367-1513-48d7-b2d0-134a00563b7c.png)


I think the easiest way to tag monitoring target is to create dns records mainnet.lsc.lido.fi and testnet.lsc.lido.fi pointing to the host ip address and put them to `GF_SERVER_ROOT_URL` variable.

NOTICE: for now there are required three .env file(see readme), may we merge it into just one?