### PR TITLE
increased prometheus retention time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     image: prom/prometheus
     command:
       - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=70d
     volumes:
       - ./docker/config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus


### PR DESCRIPTION
Right now retention time has a default value = 15d, our grafana panel "missed blocks for a month" requires at least 30d retention time, cause it uses a window function over 30d to sum up all missed blocks for a period.