### PR TITLE
feat/staked-amount-monitor

### DIFF
--- a/docker/config/grafana/provisioning/dashboards/lido_basset/lido_basset.json
+++ b/docker/config/grafana/provisioning/dashboards/lido_basset/lido_basset.json
@@ -521,6 +521,140 @@
       "type": "stat"
     },
     {
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                300
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "10m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "max"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "alerting",
+        "for": "0s",
+        "frequency": "10m",
+        "handler": 1,
+        "message": "WARNING: staked Luna amount has grown greater than 300m",
+        "name": "Luna staking pool amount",
+        "noDataState": "alerting",
+        "notifications": [
+          {
+            "uid": "webhook_lido"
+          },
+          {
+            "uid": "telegram_lido"
+          }
+        ]
+      },
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 50,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "staked_uluna_amount * 10^-12",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "staked Luna",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "op": "gt",
+          "value": 300,
+          "visible": true
+        }
+      ],
+      "title": "Luna staking pool, millions",
+      "type": "timeseries"
+    },
+    {
       "datasource": null,
       "fieldConfig": {
         "defaults": {

--- a/docker/config/grafana/provisioning/dashboards/lido_basset/lido_basset.json
+++ b/docker/config/grafana/provisioning/dashboards/lido_basset/lido_basset.json
@@ -527,7 +527,7 @@
           {
             "evaluator": {
               "params": [
-                600
+                800
               ],
               "type": "gt"
             },
@@ -552,7 +552,7 @@
         "for": "0s",
         "frequency": "10m",
         "handler": 1,
-        "message": "WARNING: staked Luna amount has grown greater than 600m",
+        "message": "WARNING: staked Luna amount has grown greater than 800m",
         "name": "Luna staking pool amount",
         "noDataState": "alerting",
         "notifications": [

--- a/docker/config/grafana/provisioning/dashboards/lido_basset/lido_basset.json
+++ b/docker/config/grafana/provisioning/dashboards/lido_basset/lido_basset.json
@@ -527,7 +527,7 @@
           {
             "evaluator": {
               "params": [
-                300
+                600
               ],
               "type": "gt"
             },
@@ -552,7 +552,7 @@
         "for": "0s",
         "frequency": "10m",
         "handler": 1,
-        "message": "WARNING: staked Luna amount has grown greater than 300m",
+        "message": "WARNING: staked Luna amount has grown greater than 600m",
         "name": "Luna staking pool amount",
         "noDataState": "alerting",
         "notifications": [

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/cosmos/cosmos-sdk v0.44.4
 	github.com/gorilla/mux v1.8.0
-	github.com/lidofinance/terra-fcd-rest-client v0.0.0-20211216152113-d81abb9b5b2f
+	github.com/lidofinance/terra-fcd-rest-client v0.0.0-20220512130920-2131001551bd
 	github.com/lidofinance/terra-repositories v0.0.0-20211216152128-33a198aeb9d9
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -628,6 +628,10 @@ github.com/libp2p/go-buffer-pool v0.0.2/go.mod h1:MvaB6xw5vOrDl8rYZGLFdKAuk/hRoR
 github.com/lidofinance/terra-fcd-rest-client v0.0.0-20211213162754-cf6489ae3534/go.mod h1:KLcUnf1uqndQVd4mr196Nj+07lEfKGj4RUxxuBEx8TA=
 github.com/lidofinance/terra-fcd-rest-client v0.0.0-20211216152113-d81abb9b5b2f h1:ujMvDoizzQ/pwTVy2eQAAOxkTR55hSeSxxFXNmI3Ve4=
 github.com/lidofinance/terra-fcd-rest-client v0.0.0-20211216152113-d81abb9b5b2f/go.mod h1:KLcUnf1uqndQVd4mr196Nj+07lEfKGj4RUxxuBEx8TA=
+github.com/lidofinance/terra-fcd-rest-client v0.0.0-20220512112516-5f4b197afefe h1:epEv6jpsYfoKYfdzKocOoG2I9J1cfQ6jvPqOD/FflYw=
+github.com/lidofinance/terra-fcd-rest-client v0.0.0-20220512112516-5f4b197afefe/go.mod h1:KLcUnf1uqndQVd4mr196Nj+07lEfKGj4RUxxuBEx8TA=
+github.com/lidofinance/terra-fcd-rest-client v0.0.0-20220512130920-2131001551bd h1:qWA0e6Q/UVjib/Po/lmGdAfBurCPV+q24WGnQwD/uzY=
+github.com/lidofinance/terra-fcd-rest-client v0.0.0-20220512130920-2131001551bd/go.mod h1:KLcUnf1uqndQVd4mr196Nj+07lEfKGj4RUxxuBEx8TA=
 github.com/lidofinance/terra-repositories v0.0.0-20211216152128-33a198aeb9d9 h1:Hwh6u+yn87Hkxys+rH8jvI/hGKCXpABtL6IUWFMl4zw=
 github.com/lidofinance/terra-repositories v0.0.0-20211216152128-33a198aeb9d9/go.mod h1:8SJTLh0zjvuV/P7rJvPbccYXxSa2bPPpTL7QCdCYLPo=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=

--- a/internal/app/collector/collector.go
+++ b/internal/app/collector/collector.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/lidofinance/terra-fcd-rest-client/columbus-5/client"
 	"github.com/lidofinance/terra-monitors/internal/app/collector/monitors"
 	"github.com/lidofinance/terra-monitors/internal/app/collector/repositories"
 	"github.com/lidofinance/terra-monitors/internal/app/config"
 	"github.com/lidofinance/terra-monitors/internal/pkg/utils"
-
-	"github.com/lidofinance/terra-fcd-rest-client/columbus-5/client"
 	"github.com/lidofinance/terra-repositories/delegations"
 	"github.com/lidofinance/terra-repositories/signinfo"
 
@@ -86,6 +85,9 @@ func New(cfg config.CollectorConfig, logger *logrus.Logger) (*Collector, error) 
 
 	oracleParamsMonitor := monitors.NewOracleParamsMonitor(cfg, logger)
 	c.RegisterMonitor(ctx, cfg, oracleParamsMonitor)
+
+	stakedLunaMonitor := monitors.NewStakedLunaAmountMonitor(logger)
+	c.RegisterMonitor(ctx, cfg, stakedLunaMonitor)
 
 	return c, nil
 }

--- a/internal/app/collector/collector.go
+++ b/internal/app/collector/collector.go
@@ -86,7 +86,7 @@ func New(cfg config.CollectorConfig, logger *logrus.Logger) (*Collector, error) 
 	oracleParamsMonitor := monitors.NewOracleParamsMonitor(cfg, logger)
 	c.RegisterMonitor(ctx, cfg, oracleParamsMonitor)
 
-	stakedLunaMonitor := monitors.NewStakedLunaAmountMonitor(logger)
+	stakedLunaMonitor := monitors.NewStakedLunaAmountMonitor(cfg, logger)
 	c.RegisterMonitor(ctx, cfg, stakedLunaMonitor)
 
 	return c, nil

--- a/internal/app/collector/monitors/staked_luna_amount_monitor.go
+++ b/internal/app/collector/monitors/staked_luna_amount_monitor.go
@@ -1,0 +1,126 @@
+package monitors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/lidofinance/terra-fcd-rest-client/columbus-5/client/staking"
+
+	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	stakedLunaAmount   MetricName = "staked_uluna_amount"
+	stakingPoolInfoUrl string     = "https://fcd.terra.dev/staking/pool"
+)
+
+type StakedLunaAmountMonitor struct {
+	metrics map[MetricName]MetricValue
+	client  *http.Client
+	logger  *logrus.Logger
+	lock    sync.RWMutex
+}
+
+func NewStakedLunaAmountMonitor(logger *logrus.Logger) *StakedLunaAmountMonitor {
+	m := StakedLunaAmountMonitor{
+		metrics: make(map[MetricName]MetricValue),
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		logger: logger,
+		lock:   sync.RWMutex{},
+	}
+	m.InitMetrics()
+	return &m
+}
+
+func (m *StakedLunaAmountMonitor) Name() string {
+	return "StakedLunaAmount"
+}
+
+func (m *StakedLunaAmountMonitor) providedMetrics() []MetricName {
+	return []MetricName{
+		stakedLunaAmount,
+	}
+}
+
+func (m *StakedLunaAmountMonitor) InitMetrics() {
+	initMetrics(m.providedMetrics(), nil, m.metrics, nil)
+}
+
+func (m *StakedLunaAmountMonitor) Handler(ctx context.Context) error {
+	p := staking.GetStakingPoolParams{}
+	p.SetContext(ctx)
+
+	resp, err := m.client.Get(stakingPoolInfoUrl)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return fmt.Errorf("get staking pool request failed: %w", err)
+	}
+
+	d, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read get staking pool resp body: %w", err)
+	}
+
+	var pool stakingPoolInfoResp
+	if err := json.Unmarshal(d, &pool); err != nil {
+		return fmt.Errorf("failed to unmarshal staking pool resp to stakingPoolInfoResp: %w", err)
+	}
+
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	m.setStringMetric(stakedLunaAmount, pool.Result.BondedTokens)
+	m.logger.Infoln("updated StakedLunaAmount")
+	return nil
+}
+
+func (m *StakedLunaAmountMonitor) setStringMetric(metric MetricName, rawValue string) {
+	v, err := cosmostypes.NewDecFromStr(rawValue)
+	if err != nil {
+		m.logger.Errorf("failed to set value \"%s\" to metric \"%s\": %+v\n", rawValue, metric, err)
+		return
+	}
+
+	value, err := v.Float64()
+	if err != nil {
+		m.logger.Errorf("failed to get float64 value from string \"%s\" for metric \"%s\": %+v\n", rawValue, metric, err)
+		return
+	}
+
+	if m.metrics[metric] == nil {
+		m.metrics[metric] = &SimpleMetricValue{}
+	}
+
+	m.metrics[metric].Set(value)
+}
+
+func (m *StakedLunaAmountMonitor) GetMetrics() map[MetricName]MetricValue {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return m.metrics
+}
+
+func (m *StakedLunaAmountMonitor) GetMetricVectors() map[MetricName]*MetricVector {
+	return nil
+}
+
+func (m *StakedLunaAmountMonitor) SetLogger(l *logrus.Logger) {
+	m.logger = l
+}
+
+type stakingPoolInfoResp struct {
+	Height string `json:"height"`
+	Result struct {
+		NotBondedTokens string `json:"not_bonded_tokens"`
+		BondedTokens    string `json:"bonded_tokens"`
+	} `json:"result"`
+}


### PR DESCRIPTION
Added a new monitor and a corresponding panel panel that shows amount of staked Luna. It's configured to alert if the amount is greater than 300 millions which would mean that stake has grown significantly and there could be a malicious user.

<img width="1440" alt="Screen Shot 2022-05-11 at 21 20 17" src="https://user-images.githubusercontent.com/34917380/167919232-9de3974f-dd9a-439b-89f6-748a743459eb.png">
<img width="1093" alt="Screen Shot 2022-05-11 at 21 19 47" src="https://user-images.githubusercontent.com/34917380/167919209-4dd480d3-9521-4e8c-8c83-25d5aa2f776e.png">
<img width="1096" alt="Screen Shot 2022-05-11 at 21 19 59" src="https://user-images.githubusercontent.com/34917380/167919224-f93cff71-4a01-4924-9cf9-e52eb9e6d2fa.png">